### PR TITLE
fix(notification-hub): minimize false positives on the NH alerts

### DIFF
--- a/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common.tf
+++ b/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common.tf
@@ -66,16 +66,16 @@ resource "azurerm_monitor_metric_alert" "alert_nh_common_pns_errors" {
   scopes        = [azurerm_notification_hub.common.id]
   description   = "Notification Hub Legacy incurred in PNS errors, please check. Runbook: not needed."
   severity      = 1
-  window_size   = "PT5M"
-  frequency     = "PT1M"
+  window_size   = "PT30M"
+  frequency     = "PT5M"
   auto_mitigate = false
 
-  criteria {
+  dynamic_criteria {
     metric_namespace       = "Microsoft.NotificationHubs/namespaces/notificationHubs"
     metric_name            = "outgoing.allpns.pnserror"
+    alert_sensitivity      = "Medium"
     aggregation            = "Total"
     operator               = "GreaterThan"
-    threshold              = 0
     skip_metric_validation = false
   }
 

--- a/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_1.tf
+++ b/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_1.tf
@@ -57,16 +57,16 @@ resource "azurerm_monitor_metric_alert" "alert_nh_common_partition_1_pns_errors"
   scopes        = [azurerm_notification_hub.common_partition_1.id]
   description   = "Notification Hub Partition 1 incurred in PNS errors, please check. Runbook: not needed."
   severity      = 1
-  window_size   = "PT5M"
-  frequency     = "PT1M"
+  window_size   = "PT30M"
+  frequency     = "PT5M"
   auto_mitigate = false
 
-  criteria {
+  dynamic_criteria {
     metric_namespace       = "Microsoft.NotificationHubs/namespaces/notificationHubs"
     metric_name            = "outgoing.allpns.pnserror"
+    alert_sensitivity      = "Medium"
     aggregation            = "Total"
     operator               = "GreaterThan"
-    threshold              = 10
     skip_metric_validation = false
   }
 

--- a/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_2.tf
+++ b/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_2.tf
@@ -57,16 +57,16 @@ resource "azurerm_monitor_metric_alert" "alert_nh_common_partition_2_pns_errors"
   scopes        = [azurerm_notification_hub.common_partition_2.id]
   description   = "Notification Hub Partition 2 incurred in PNS errors, please check. Runbook: not needed."
   severity      = 1
-  window_size   = "PT5M"
-  frequency     = "PT1M"
+  window_size   = "PT30M"
+  frequency     = "PT5M"
   auto_mitigate = false
 
-  criteria {
+  dynamic_criteria {
     metric_namespace       = "Microsoft.NotificationHubs/namespaces/notificationHubs"
     metric_name            = "outgoing.allpns.pnserror"
+    alert_sensitivity      = "Medium"
     aggregation            = "Total"
     operator               = "GreaterThan"
-    threshold              = 10
     skip_metric_validation = false
   }
 

--- a/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_3.tf
+++ b/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_3.tf
@@ -57,16 +57,16 @@ resource "azurerm_monitor_metric_alert" "alert_nh_common_partition_3_pns_errors"
   scopes        = [azurerm_notification_hub.common_partition_3.id]
   description   = "Notification Hub Partition 3 incurred in PNS errors, please check. Runbook: not needed."
   severity      = 1
-  window_size   = "PT5M"
-  frequency     = "PT1M"
+  window_size   = "PT30M"
+  frequency     = "PT5M"
   auto_mitigate = false
 
-  criteria {
+  dynamic_criteria {
     metric_namespace       = "Microsoft.NotificationHubs/namespaces/notificationHubs"
     metric_name            = "outgoing.allpns.pnserror"
+    alert_sensitivity      = "Medium"
     aggregation            = "Total"
     operator               = "GreaterThan"
-    threshold              = 10
     skip_metric_validation = false
   }
 

--- a/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_4.tf
+++ b/infra/resources/_modules/notification_hubs/notification_hub_ntfns_common_partition_4.tf
@@ -57,16 +57,16 @@ resource "azurerm_monitor_metric_alert" "alert_nh_common_partition_4_pns_errors"
   scopes        = [azurerm_notification_hub.common_partition_4.id]
   description   = "Notification Hub Partition 4 incurred in PNS errors, please check. Runbook: not needed."
   severity      = 1
-  window_size   = "PT5M"
-  frequency     = "PT1M"
+  window_size   = "PT30M"
+  frequency     = "PT5M"
   auto_mitigate = false
 
-  criteria {
+  dynamic_criteria {
     metric_namespace       = "Microsoft.NotificationHubs/namespaces/notificationHubs"
     metric_name            = "outgoing.allpns.pnserror"
+    alert_sensitivity      = "Medium"
     aggregation            = "Total"
     operator               = "GreaterThan"
-    threshold              = 10
     skip_metric_validation = false
   }
 

--- a/infra/resources/prod/.terraform.lock.hcl
+++ b/infra/resources/prod/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.116.0"
+  constraints = "~> 3.30, ~> 3.76, != 3.97.0, != 3.97.1, >= 3.100.0, >= 3.111.0, <= 3.116.0"
+  hashes = [
+    "h1:BCR3NIorFSvGG3v/+JOiiw3VM4PkChLO4m84wzD9NDo=",
+    "zh:02b6606aff025fc2a962b3e568e000300abe959adac987183c24dac8eb057f4d",
+    "zh:2a23a8ce24ff9e885925ffee0c3ea7eadba7a702541d05869275778aa47bdea7",
+    "zh:57d10746384baeca4d5c56e88872727cdc150f437b8c5e14f0542127f7475e24",
+    "zh:59e3ebde1a2e1e094c671e179f231ead60684390dbf02d2b1b7fe67a228daa1a",
+    "zh:5f1f5c7d09efa2ee8ddf21bd9efbbf8286f6e90047556bef305c062fa0ac5880",
+    "zh:a40646aee3c9907276dab926e6123a8d70b1e56174836d4c59a9992034f88d70",
+    "zh:c21d40461bc5836cf56ad3d93d2fc47f61138574a55e972ad5ff1cb73bab66dc",
+    "zh:c56fb91a5ae66153ba0f737a26da1b3d4f88fdef7d41c63e06c5772d93b26953",
+    "zh:d1e60e85f51d12fc150aeab8e31d3f18f859c32f927f99deb5b74cb1e10087aa",
+    "zh:ed35e727e7d79e687cd3d148f52b442961ede286e7c5b4da1dcd9f0128009466",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f6d2a4e7c58f44e7d04a4a9c73f35ed452f412c97c85def68c4b52814cbe03ab",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.3"
+  hashes = [
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
+    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
+    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
+    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
+    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
+    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
+    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
+    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
+    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
+    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
+    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
+  ]
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

Updated rules for "Push Notification Service errors" alerts in order to minimize false positives.
What I've updated:

* Increased `window_size` and `frequency`;
* Removed static criterias in favour of `dynamic_criterias`;

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The alert "Push Notification Service errors" is too sensitive.
You can find a before and after in the screenshot section.

#### Screenshots (if appropriate):
Before
![2024-11-06_11-03](https://github.com/user-attachments/assets/1e4998b1-bcc1-4725-826d-df48de5aeb3c)
After
![2024-11-06_11-04](https://github.com/user-attachments/assets/0da66923-855d-4e50-8bb3-710dded2af61)


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
