### PR TITLE
[CES-728] Switch back to access keys when accessing Storage Accounts

### DIFF
--- a/infra/resources/prod/main.tf
+++ b/infra/resources/prod/main.tf
@@ -22,7 +22,6 @@ terraform {
 
 provider "azurerm" {
   features {}
-  storage_use_azuread = true
 }
 
 module "redis_messages" {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Switch back to access keys when accessing Storage Accounts

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Table storage cannot be read using AD by the Terraform provider. Then, it is necessary to switch back to the access keys

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
