### PR TITLE
Move citizen-func to Italy North

### DIFF
--- a/.github/workflows/deploy-citizen-func.yaml
+++ b/.github/workflows/deploy-citizen-func.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  deploy_citizen_func_01:
+  citizen_func_deploy:
     uses: pagopa/dx/.github/workflows/function_app_deploy.yaml@e97c785579f7b027d95d449062073d46fafd2e79
     secrets: inherit
     with:
@@ -12,17 +12,5 @@ jobs:
       environment: app-prod
       resource_group_name: io-p-weu-com-rg-01
       function_app_name: io-p-weu-com-citizen-func-01
-      health_check_path: "/api/v1/info"
-      use_staging_slot: true
-
-  deploy_citizen_func_02:
-    uses: pagopa/dx/.github/workflows/function_app_deploy.yaml@e97c785579f7b027d95d449062073d46fafd2e79
-    secrets: inherit
-    needs: [deploy_citizen_func_01]
-    with:
-      workspace_name: citizen-func
-      environment: app-prod
-      resource_group_name: io-p-weu-com-rg-01
-      function_app_name: io-p-weu-com-citizen-func-02
       health_check_path: "/api/v1/info"
       use_staging_slot: true

--- a/infra/resources/_modules/web_apps/citizen-func.tf
+++ b/infra/resources/_modules/web_apps/citizen-func.tf
@@ -1,0 +1,95 @@
+locals {
+  citizen_func = {
+    app_settings = {
+      NODE_ENV = "production"
+
+      // APP INSIGHTS
+      APPINSIGHTS_INSTRUMENTATIONKEY  = var.application_insights.instrumentation_key
+      APPINSIGHTS_CONNECTION_STRING   = var.application_insights.connection_string
+      APPINSIGHTS_SAMPLING_PERCENTAGE = 5
+
+      // IO COSMOSDB
+      COSMOSDB_NAME = "db"
+      COSMOSDB_URI  = var.cosmosdb_account_api.endpoint
+      COSMOSDB_KEY  = var.cosmosdb_account_api.primary_key
+
+      // REMOTE CONTENT COSMOSDB
+      REMOTE_CONTENT_COSMOSDB_NAME = "remote-content-cosmos-01"
+      REMOTE_CONTENT_COSMOSDB_URI  = var.io_com_cosmos.endpoint
+      REMOTE_CONTENT_COSMOSDB_KEY  = var.io_com_cosmos.primary_key
+
+      // BLOB STORAGE
+      MESSAGE_CONTENT_STORAGE_CONNECTION_STRING = var.message_content_storage.connection_string
+      MESSAGE_CONTAINER_NAME                    = "message-content"
+
+      // REDIS
+      REDIS_URL      = var.redis_cache.hostname
+      REDIS_PORT     = var.redis_cache.port
+      REDIS_PASSWORD = var.redis_cache.access_key
+
+      // INTERNAL USE PROPERTIES
+      PN_SERVICE_ID              = "01G40DWQGKY5GRWSNM4303VNRP" # PN
+      SERVICE_CACHE_TTL_DURATION = "28800"                      # 8 hours
+      RC_CONFIGURATION_CACHE_TTL = "28800"
+      SERVICE_TO_RC_CONFIGURATION_MAP = jsonencode({
+        "01G40DWQGKY5GRWSNM4303VNRP" = "01HMVMHCZZ8D0VTFWMRHBM5D6F", # PN
+        "01GQQZ9HF5GAPRVKJM1VDAVFHM" = "01HMVMDTHXCESMZ72NA701EKGQ", # IO Sign
+        "01H4ZJ62C1CPGJ0PX8Q1BP7FAB" = "01HMVMCDD3JFYTPKT4ZN4WQ73B", # PagoPA Receipt (Test)
+        "01HD63674XJ1R6XCNHH24PCRR2" = "01HMVM9W74RWH93NT1EYNKKNNR", # PagoPA Receipt
+        "01GQQDPM127KFGG6T3660D5TXD" = "01HMVM4N4XFJ8VBR1FXYFZ9QFB", # Third Party Mock
+      })
+
+      // MESSAGE VIEW FF
+      USE_FALLBACK          = false
+      FF_TYPE               = "none"
+      FF_BETA_TESTER_LIST   = "[]"
+      FF_CANARY_USERS_REGEX = "^([(0-9)|(a-f)|(A-F)]{62}00)$" // takes 0.4% of users
+
+      // Keepalive fields are all optionals
+      FETCH_KEEPALIVE_ENABLED             = "true"
+      FETCH_KEEPALIVE_SOCKET_ACTIVE_TTL   = "110000"
+      FETCH_KEEPALIVE_MAX_SOCKETS         = "40"
+      FETCH_KEEPALIVE_MAX_FREE_SOCKETS    = "10"
+      FETCH_KEEPALIVE_FREE_SOCKET_TIMEOUT = "30000"
+      FETCH_KEEPALIVE_TIMEOUT             = "60000"
+    }
+  }
+}
+
+
+module "citizen_func" {
+  source  = "pagopa/dx-azure-function-app/azurerm"
+  version = "~>0"
+
+  environment = merge(var.environment, {
+    app_name        = "citizen"
+    instance_number = "01"
+  })
+
+  resource_group_name = var.resource_group_name
+  health_check_path   = "/api/v1/info"
+  node_version        = 20
+
+  tier = "xl"
+
+  subnet_cidr                          = var.subnet_cidrs.citizen_func
+  subnet_pep_id                        = var.subnet_pep_id
+  private_dns_zone_resource_group_name = var.private_dns_zone_resource_group_name
+
+  virtual_network = {
+    name                = var.virtual_network.name
+    resource_group_name = var.virtual_network.resource_group_name
+  }
+
+  app_settings      = local.citizen_func.app_settings
+  slot_app_settings = local.citizen_func.app_settings
+
+  tags = var.tags
+
+  action_group_id = var.action_group_id
+}
+
+resource "azurerm_subnet_nat_gateway_association" "functions_messages_citizen_subnet" {
+  subnet_id      = module.citizen_func.subnet.id
+  nat_gateway_id = var.nat_gateway_id
+}

--- a/infra/resources/_modules/web_apps/locals.tf
+++ b/infra/resources/_modules/web_apps/locals.tf
@@ -7,7 +7,7 @@ locals {
       APPINSIGHTS_CONNECTION_STRING                  = var.application_insights.connection_string
       APPINSIGHTS_SAMPLING_PERCENTAGE                = 100
       FUNCTIONS_WORKER_RUNTIME                       = "node",
-      MESSAGE_CONTENT_STORAGE_URI                    = var.app_settings.message_content_storage_uri
+      MESSAGE_CONTENT_STORAGE_URI                    = var.message_content_storage.endpoint
       EVENTHUB_CONNECTION_URI                        = var.app_settings.eventhub_connection_uri,
       MESSAGE_CONTENT_CONTAINER_NAME                 = "message-content",
       MESSAGE_EVENTHUB_NAME                          = "io-p-itn-com-etl-messages-evh-01"
@@ -16,7 +16,7 @@ locals {
       PDV_TOKENIZER_BASE_URL                         = "https://api.tokenizer.pdv.pagopa.it/tokenizer/v1"
       REDIS_PASSWORD                                 = var.redis_cache.access_key
       REDIS_PING_INTERVAL                            = 1000 * 60 * 9
-      REDIS_URL                                      = var.redis_cache.url
+      REDIS_URL                                      = "rediss://${var.redis_cache.hostname}:${var.redis_cache.port}",
       COMMON_COSMOS__accountEndpoint                 = var.cosmosdb_account_api.endpoint
       COMMON_COSMOS_DBNAME                           = "db",
       COMMON_COSMOS_MESSAGES_CONTAINER_NAME          = "messages-dataplan-ingestion-test"

--- a/infra/resources/_modules/web_apps/variables.tf
+++ b/infra/resources/_modules/web_apps/variables.tf
@@ -37,24 +37,15 @@ variable "subnet_pep_id" {
 
 variable "subnet_cidrs" {
   type = object({
-    notif_func = string
+    notif_func   = string
+    citizen_func = string
   })
 }
 
-/*variable "gcm_migration_storage" {
-  type = object({
-    id             = string
-    blob_endpoint  = string
-    queue_endpoint = string
-    queue = object({
-      name = string
-    })
-  })
-}*/
-
 variable "application_insights" {
   type = object({
-    connection_string = string
+    connection_string   = string
+    instrumentation_key = string
   })
 }
 
@@ -98,6 +89,7 @@ variable "cosmosdb_account_api" {
     id                  = string
     name                = string
     endpoint            = string
+    primary_key         = string
     resource_group_name = string
   })
 }
@@ -108,6 +100,7 @@ variable "io_com_cosmos" {
     name                = string
     endpoint            = string
     resource_group_name = string
+    primary_key         = string
   })
 }
 
@@ -122,16 +115,28 @@ variable "action_group_id" {
 
 variable "app_settings" {
   type = object({
-    message_content_storage_uri : string,
-    message_error_table_storage_uri : string,
-    eventhub_connection_uri : string,
+    message_error_table_storage_uri = string,
+    eventhub_connection_uri         = string,
+  })
+}
+
+variable "message_content_storage" {
+  type = object({
+    endpoint          = string
+    connection_string = string
   })
 }
 
 variable "redis_cache" {
   type = object({
     id         = string
-    url        = string
+    hostname   = string
+    port       = string
     access_key = string
   })
+}
+
+variable "nat_gateway_id" {
+  type        = string
+  description = "The ID of the NAT Gateway"
 }

--- a/infra/resources/prod/web_apps.tf
+++ b/infra/resources/prod/web_apps.tf
@@ -23,32 +23,32 @@ module "web_apps" {
   subnet_pep_id = data.azurerm_subnet.pep.id
 
   subnet_cidrs = {
-    notif_func = "10.20.8.0/26"
+    notif_func   = "10.20.8.0/26"
+    citizen_func = "10.20.8.64/26"
   }
 
+  nat_gateway_id = data.azurerm_nat_gateway.itn_ng.id
+
   app_settings = {
-    message_content_storage_uri : data.azurerm_storage_account.storage_api.primary_blob_endpoint,
     message_error_table_storage_uri : data.azurerm_storage_account.storage_api.primary_table_endpoint,
     eventhub_connection_uri : "${data.azurerm_eventhub_namespace.etl_eventhub_namespace.name}.servicebus.windows.net"
   }
 
-  redis_cache = {
-    id         = module.redis_messages.id
-    url        = "rediss://${module.redis_messages.hostname}:${module.redis_messages.ssl_port}"
-    access_key = module.redis_messages.primary_access_key
+  message_content_storage = {
+    endpoint          = data.azurerm_storage_account.storage_api.primary_blob_endpoint
+    connection_string = data.azurerm_storage_account.storage_api.primary_connection_string
   }
 
-  /*gcm_migration_storage = {
-    id             = data.azurerm_storage_account.iopstexportdata.id,
-    blob_endpoint  = data.azurerm_storage_account.iopstexportdata.primary_blob_endpoint
-    queue_endpoint = data.azurerm_storage_account.iopstexportdata.primary_queue_endpoint
-    queue          = azurerm_storage_queue.gcm_migrations
-  }*/
+  redis_cache = {
+    id         = module.redis_messages.id
+    hostname   = module.redis_messages.hostname
+    port       = module.redis_messages.ssl_port
+    access_key = module.redis_messages.primary_access_key
+  }
 
   application_insights = data.azurerm_application_insights.common
 
   common_key_vault = data.azurerm_key_vault.weu_common
-
 
   eventhub_namespace                   = data.azurerm_eventhub_namespace.etl_eventhub_namespace
   messages_content_container           = data.azurerm_storage_container.messages_content_container


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
1. Move the `citizen-func` infra code into `web_apps` module
2. Scale up from `l` to `xl`
3. Remove the second instance, we will use only `citizen-func-01` from now

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
1. The messages db was replicated to `Italy North` so we safely move our computing resources into the same region
2. We are trying to simplify the architecture, using only one instance (`xl`) instead of two smaller ones