### PR TITLE
Set `io-messages-common` version

### DIFF
--- a/packages/io-messages-common/package.json
+++ b/packages/io-messages-common/package.json
@@ -1,6 +1,8 @@
 {
   "name": "io-messages-common",
   "license": "UNLICENSED",
+  "version": "1.0.0",
+  "private": true,
   "type": "module",
   "exports": {
     "./*": "./dist/*.js"


### PR DESCRIPTION
This change fixes a problem on `release.yaml` workflow, that is blocked due to the lack of `"version"` of this package that is a dependency for `etl-func`