### PR TITLE
Replace role for Infra CD identity to manage roles of cosmos-api

### DIFF
--- a/infra/resources/prod/README.md
+++ b/infra/resources/prod/README.md
@@ -36,7 +36,7 @@
 | [azurerm_resource_group.notifications](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 | [azurerm_role_assignment.admins_group_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.app_cd_rg_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.cosmos_api_infra_cd_rbac_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cosno_api_infra_cd_account_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.devs_group_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.devs_group_rg_com_eh](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_common_itn_01_rbac_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |

--- a/infra/resources/prod/iam.tf
+++ b/infra/resources/prod/iam.tf
@@ -1,5 +1,5 @@
-resource "azurerm_role_assignment" "cosmos_api_infra_cd_rbac_admin" {
+resource "azurerm_role_assignment" "cosno_api_infra_cd_account_contributor" {
   scope                = data.azurerm_cosmosdb_account.cosmos_api.id
-  role_definition_name = "Role Based Access Control Administrator"
+  role_definition_name = "DocumentDB Account Contributor"
   principal_id         = data.azurerm_user_assigned_identity.infra_cd_01.principal_id
 }


### PR DESCRIPTION
Infra CD identity now has `DocumentDB Account Contributor` role to manage role assignments (and more) at cosmos-api scope

Resolves: IOCOM-2167