### PR TITLE
Change `io-p-itn-msgs-redis-01` sku_name

### DIFF
--- a/infra/resources/prod/main.tf
+++ b/infra/resources/prod/main.tf
@@ -33,7 +33,7 @@ module "redis_messages" {
 
   capacity              = 2
   family                = "C"
-  sku_name              = "Premium"
+  sku_name              = "Standard"
   redis_version         = "6"
   enable_authentication = true
   zones                 = [1, 2]


### PR DESCRIPTION
Set `Standard` as `sku_name`, since `Premium` is not a valid option for `C` family