### PR TITLE
Enable `storage_use_azuread`

### DIFF
--- a/infra/resources/prod/main.tf
+++ b/infra/resources/prod/main.tf
@@ -22,6 +22,7 @@ terraform {
 
 provider "azurerm" {
   features {}
+  storage_use_azuread = true
 }
 
 module "redis_messages" {


### PR DESCRIPTION
With this flag enabled `azurerm` will use Azure AD to connect to storage resources instead of keys