### PR TITLE
Fix summary collection in IngestMessage

### DIFF
--- a/apps/etl-func/src/domain/use-cases/ingest-message.ts
+++ b/apps/etl-func/src/domain/use-cases/ingest-message.ts
@@ -43,7 +43,7 @@ export class IngestMessageUseCase {
 
     if (messagesEvent.length > 0) {
       await this.#eventProducer.publish(messagesEvent);
-      this.#eventSummaryCollector.collect(messagesEvent.length);
+      await this.#eventSummaryCollector.collect(messagesEvent.length);
     }
   }
 }


### PR DESCRIPTION
During the last load test, we encountered a discrepancy between the number of messages received in the Event Hub and the summaries. This could be the cause.