### PR TITLE
Add bruno endpoints for `io-backend`

### DIFF
--- a/bruno/bruno.json
+++ b/bruno/bruno.json
@@ -2,8 +2,8 @@
   "version": "1",
   "name": "io-messages",
   "type": "collection",
-  "ignore": [
-    "node_modules",
-    ".git"
-  ]
+  "ignore": ["node_modules", ".git"],
+  "scripts": {
+    "moduleWhitelist": ["crypto"]
+  }
 }

--- a/bruno/citizen-func/GetMessage.bru
+++ b/bruno/citizen-func/GetMessage.bru
@@ -1,11 +1,16 @@
 meta {
   name: GetMessage
   type: http
-  seq: 3
+  seq: 4
 }
 
 get {
-  url: {{citizen_func_url}}/api/v1/messages/{{fiscal-code}}/{{message-id}}
+  url: {{citizen_func_url}}/api/v1/messages/:fiscal_code/:message_id
   body: none
   auth: none
+}
+
+params:path {
+  fiscal_code: {{fiscal_code}}
+  message_id: {{message_id}}
 }

--- a/bruno/citizen-func/GetMessages.bru
+++ b/bruno/citizen-func/GetMessages.bru
@@ -1,11 +1,19 @@
 meta {
   name: GetMessages
   type: http
-  seq: 4
+  seq: 3
 }
 
 get {
-  url: {{citizen_func_url}}/api/v1/messages/{{fiscal-code}}
+  url: {{citizen_func_url}}/api/v1/messages/:fiscal_code
   body: none
   auth: none
+}
+
+params:path {
+  fiscal_code: {{fiscal_code}}
+}
+
+vars:post-response {
+  message_id: res.body.items[0].id
 }

--- a/bruno/citizen-func/GetRCConfiguration.bru
+++ b/bruno/citizen-func/GetRCConfiguration.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{citizen_func_url}}/api/v1/remote-contents/configurations/{{configuration-id}}
+  url: {{citizen_func_url}}/api/v1/remote-contents/configurations/{{configuration_id}}
   body: none
   auth: none
 }

--- a/bruno/citizen-func/Info.bru
+++ b/bruno/citizen-func/Info.bru
@@ -9,3 +9,8 @@ get {
   body: none
   auth: none
 }
+
+assert {
+  res.status: eq 200
+  res.body.name: eq citizen-func
+}

--- a/bruno/citizen-func/UpsertMessageStatus.bru
+++ b/bruno/citizen-func/UpsertMessageStatus.bru
@@ -5,9 +5,14 @@ meta {
 }
 
 put {
-  url: {{citizen_func_url}}/api/v1/messages/{{fiscal-code}}/{{message-id}}/message-status
+  url: {{citizen_func_url}}/api/v1/messages/:fiscal_code/:message_id/message-status
   body: json
   auth: none
+}
+
+params:path {
+  message_id: {{message_id}}
+  fiscal_code: {{fiscal_code}}
 }
 
 body:json {

--- a/bruno/collection.bru
+++ b/bruno/collection.bru
@@ -1,5 +1,3 @@
 vars:pre-request {
-  fiscal-code: LVTEST00A00A192X
-  message-id: 01J0QWGC8K6W83Z2VP24ZYQFZ2
-  configuration-id: 01HMVMCDD3JFYTPKT4ZN4WQ73B
+  configuration_id: 01HMVMCDD3JFYTPKT4ZN4WQ73B
 }

--- a/bruno/environments/Production.bru
+++ b/bruno/environments/Production.bru
@@ -1,6 +1,7 @@
 vars {
   citizen_func_url: https://io-p-itn-com-citizen-func-01.azurewebsites.net
   sending_func_url: https://io-p-itn-msgs-sending-func-01.azurewebsites.net
+  app_backend_public_url: https://api-app.io.pagopa.it
 }
 vars:secret [
   citizen_func_key,

--- a/bruno/io-backend/Get Messages.bru
+++ b/bruno/io-backend/Get Messages.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Messages
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{app_backend_public_url}}/api/v1/messages
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{user_token}}
+}

--- a/bruno/io-backend/Get Session.bru
+++ b/bruno/io-backend/Get Session.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Session
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{app_backend_public_url}}/api/v1/session
+  body: none
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{user_token}}
+}

--- a/bruno/io-backend/Test Login.bru
+++ b/bruno/io-backend/Test Login.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Test Login
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{app_backend_public_url}}/test-login
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "username": "{{fiscal_code}}",
+    "password": "{{test_user_password}}"
+  }
+}
+
+vars:post-response {
+  user_token: res.body.token
+}
+
+script:pre-request {
+  const crypto = require("node:crypto");
+  
+  const { publicKey } = crypto.generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+    publicKeyEncoding: {
+      type: "spki",
+      format: "jwk",
+    },
+  });
+  
+  const jwk = JSON.stringify(publicKey);
+  const encoded = Buffer.from(jwk).toString("base64url");
+  
+  req.setHeader("x-pagopa-lollipop-pub-key", encoded);
+}

--- a/bruno/sending-func/Info.bru
+++ b/bruno/sending-func/Info.bru
@@ -9,3 +9,8 @@ get {
   body: none
   auth: none
 }
+
+assert {
+  res.status: eq 200
+  res.body.name: eq sending-func
+}


### PR DESCRIPTION
Add `Test Login`, `Get Session` and `Get Messages` from public `io-backend` service. This change also includes a small refactor to make the config compact and idiomatic.