### PR TITLE
Fix changesets version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "turbo run format",
     "lint": "turbo run lint",
     "test:coverage": "vitest run --coverage",
-    "version": "changeset version && yarn install --mode update-lockfile",
+    "version": "changeset version && yarn install --mode update-lockfile && turbo run openapi:bundle",
     "release": "changeset tag"
   },
   "devDependencies": {


### PR DESCRIPTION
On legacy workspaces (e.g. `citizen-func`) the OpenAPI spec version should match the `package.json` version.