### PR TITLE
Configure `app-cd` deployment tags

### DIFF
--- a/infra/repository/locals.tf
+++ b/infra/repository/locals.tf
@@ -51,6 +51,7 @@ locals {
     infra_cd_policy_branches = ["main"]
     opex_cd_policy_branches  = ["main"]
     app_cd_policy_branches   = ["main"]
+    app_cd_policy_tags       = ["*@*"]
   }
 
   key_vault = {


### PR DESCRIPTION
Allow deployment to `app-cd` environment from tags that follow the `*@` pattern (e.g. `citizen-func@1.10.14`)