### PR TITLE
Make the `etl-func` workspace public

### DIFF
--- a/apps/etl-func/package.json
+++ b/apps/etl-func/package.json
@@ -1,6 +1,5 @@
 {
   "name": "etl-func",
-  "private": true,
   "main": "dist/func.js",
   "type": "module",
   "files": [


### PR DESCRIPTION
In order to allow changesets to create a GitHub releases for `etl-func`, we should mark it as public, since the release pipeline ignores all private packages.