### PR TITLE
Update citizen-func autoscaler

### DIFF
--- a/infra/resources/_modules/web_apps/citizen-func.tf
+++ b/infra/resources/_modules/web_apps/citizen-func.tf
@@ -149,5 +149,26 @@ module "citizen_func_autoscaler" {
     }
   }
 
+  scheduler = {
+    normal_load = {
+      default = 11,
+      minimum = 6
+    },
+    low_load = {
+      minimum = 2,
+      name    = "low_load_profile",
+      default = 10,
+      start = {
+        hour    = 22,
+        minutes = 0
+      }
+      end = {
+        hour    = 5,
+        minutes = 0
+      },
+    },
+    maximum = 30,
+  }
+
   tags = var.tags
 }


### PR DESCRIPTION
* Double minimum instance count on normal load, from 3 to 6
* Remove high_load_profile
* Update low_load_profile to start at 22.00 instead 23.00