### PR TITLE
Update time_window on ingestion alerts

### DIFF
--- a/.changeset/green-radios-promise.md
+++ b/.changeset/green-radios-promise.md
@@ -1,5 +1,0 @@
----
-"etl-func": patch
----
-
-fix ingestion alerts to avoid multiple alerts for a single error

--- a/.changeset/green-radios-promise.md
+++ b/.changeset/green-radios-promise.md
@@ -1,0 +1,5 @@
+---
+"etl-func": patch
+---
+
+fix ingestion alerts to avoid multiple alerts for a single error

--- a/infra/resources/_modules/monitoring/monitoring.tf
+++ b/infra/resources/_modules/monitoring/monitoring.tf
@@ -34,7 +34,7 @@ customEvents
 
   severity    = 1
   frequency   = 10
-  time_window = 30
+  time_window = 10
 
   trigger {
     operator  = "GreaterThanOrEqual"
@@ -67,7 +67,7 @@ customEvents
 
   severity    = 1
   frequency   = 10
-  time_window = 30
+  time_window = 10
 
   trigger {
     operator  = "GreaterThanOrEqual"
@@ -100,7 +100,7 @@ customEvents
 
   severity    = 1
   frequency   = 10
-  time_window = 30
+  time_window = 10
 
   trigger {
     operator  = "GreaterThanOrEqual"


### PR DESCRIPTION
Changed the ingestion alerts time windows to match the frequency in order to avoid multiple alerts for a single error