### PR TITLE
Replace sample with reminder container image

### DIFF
--- a/infra/repository/.terraform.lock.hcl
+++ b/infra/repository/.terraform.lock.hcl
@@ -26,8 +26,11 @@ provider "registry.terraform.io/hashicorp/azuread" {
 
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.20.0"
-  constraints = "~> 4.0"
+  constraints = ">= 3.110.0, ~> 4.0, < 5.0.0"
   hashes = [
+    "h1:O7hZA85M9/G5LZt+m0bppCinoyp8C346JpI+QnMjYVo=",
+    "h1:m0gw9qg+hu43PlWDZuTKCFGp0SvBJIv338lIHOqLZmU=",
+    "h1:qMMFID97Se3U3dxypUF6edxz6TJG/WQfwO1mwOd3ze4=",
     "h1:xyhSZmLLirjEN7lmrh4pdM6fOhaA0yWpHUgXdx69vV4=",
     "zh:0d29f06abed90da7b943690244420fe1de3e28d4c6de0db441f1af2aa91ea6b8",
     "zh:2345e07e91dfec9af3df25fd5119d3a09f91e37ca10af30a344f7b3c297e9ad8",
@@ -67,5 +70,31 @@ provider "registry.terraform.io/integrations/github" {
     "zh:ec0d51640c3e3cf933c73d0ed79ba8b395d1b94fed8117a6438dba872aa5561f",
     "zh:ec59b7c420a2358e9750e9c6a8a5ef26ccbb8a2cae417e115e86d63520759ea5",
     "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}
+
+provider "registry.terraform.io/pagopa-dx/azure" {
+  version     = "0.0.7"
+  constraints = ">= 0.0.6, >= 0.0.7, < 1.0.0"
+  hashes = [
+    "h1:6M25KpctmcIKSiknc1tFQ+veVslONAfsgtAIAgpPYbg=",
+    "h1:Lyjtx+od/oP0r5ShAOKrIwnvN2hM+RbvhTgjYPWQbdc=",
+    "h1:Mds3mBXpjzSXygWIVYvorasR6cGMUuSgIztA5p65V44=",
+    "h1:eohPFOFwBIJMI0tZMTQyYo/5R6QY9UCP3UDEbHPUqWI=",
+    "zh:083a88b71fda4cd46619a61cc6a1bb4be672efd07e095a6b2e3d61f633f28160",
+    "zh:4d4ea20c57cfcf7b22e4f4e3a32fb723638d72671b238ece9712163204e00541",
+    "zh:51e176cb0f14b53ba51b8c506dfb7de489f54a354a3b4fb9ae0a8804f10775fc",
+    "zh:63609f110efb188ca5c55db8ca7127038ba23df41f2a9d29255dd2281822cfc6",
+    "zh:664cab73509d7abd9546d2ea9e0539aba57ff3c93f58fd18285159f5b1083921",
+    "zh:6b9bbc07390825afc746baef3bcec0d30a91982d44b3bc949577c371c2853d33",
+    "zh:7345c37e44e108f7cbe0a106aed218f2d3604270b4a33200c38cf2562689b7fb",
+    "zh:775bd9cb0411c11bcb40646a60354e8346678c00e297bd0e1305c6dec834815f",
+    "zh:87851a0d1b88539f8ea791e5fe994627018b6ace308921f5f7abf4da6c5fc43a",
+    "zh:8da549f242706072cbe84e2f8f3ea2e4d552ae4765d72ea43c03d858bf09ec89",
+    "zh:c7279337695667acbc882c9e8c17da375402e0bd27725220f2b22e10947c963b",
+    "zh:c8676b7d35897f09555ca9a49d6b2550010ffe43c9ef40a21574054c1455705d",
+    "zh:d612cb4a5af5bb219935aa1838252ae5fcecc83d99d9adf992920876d52d41ef",
+    "zh:e16c1b87d53cebf025da536d62914010356c7f01b4c3aca5a2901748747ab4f0",
+    "zh:ed6855a5d929591548dd0ae4a28d8ad0f1418098d94ba4d90161932e4082181f",
   ]
 }

--- a/infra/repository/tfmodules.lock.json
+++ b/infra/repository/tfmodules.lock.json
@@ -1,4 +1,4 @@
 {
-  "repo": "7fc4b1fcf9fcb8498263400c246745c40c629ca29eb4ffaefece60385a41d373",
-  "repo.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4"
+  "repo": "b31acc83d85d6a94c879e59ecb12c99cc2e62ca9eed35f5c9c727030c052f4ef",
+  "repo.github_runner": "9dcc913e604025cacf32e3f6f72ff22a6495ec79bbdefd2ea94de843d1004381"
 }

--- a/infra/resources/_modules/container_apps/README.md
+++ b/infra/resources/_modules/container_apps/README.md
@@ -15,14 +15,16 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_com_cae"></a> [com\_cae](#module\_com\_cae) | pagopa-dx/azure-container-app-environment/azurerm | ~> 0.0 |
-| <a name="module_reminder_ca_itn_01"></a> [reminder\_ca\_itn\_01](#module\_reminder\_ca\_itn\_01) | pagopa-dx/azure-container-app/azurerm | ~> 0.0 |
+| <a name="module_com_cae"></a> [com\_cae](#module\_com\_cae) | pagopa-dx/azure-container-app-environment/azurerm | ~> 1.0 |
+| <a name="module_reminder_ca_itn_01"></a> [reminder\_ca\_itn\_01](#module\_reminder\_ca\_itn\_01) | pagopa-dx/azure-container-app/azurerm | ~> 1.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [azurerm_key_vault_access_policy.reminder_kv_messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_role_assignment.cae_acr_pull](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.cae_admins_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_key_vault_secret.appinsights_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.kafka_url_message](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.kafka_url_messagesend](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
@@ -42,6 +44,8 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_acr_id"></a> [acr\_id](#input\_acr\_id) | The Id of the ACR to pull images from | `string` | n/a | yes |
+| <a name="input_entra_id_admin_ids"></a> [entra\_id\_admin\_ids](#input\_entra\_id\_admin\_ids) | Id of Entra ID groups that should be admins of the Container App Environment | `set(string)` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Values which are used to generate resource names and location short names. They are all mandatory except for domain, which should not be used only in the case of a resource used by multiple domains. | <pre>object({<br/>    prefix    = string<br/>    env_short = string<br/>    location  = string<br/>    domain    = string<br/>  })</pre> | n/a | yes |
 | <a name="input_key_vault_id"></a> [key\_vault\_id](#input\_key\_vault\_id) | Id of the team domain key vault | `string` | n/a | yes |
 | <a name="input_log_analytics_workspace_id"></a> [log\_analytics\_workspace\_id](#input\_log\_analytics\_workspace\_id) | n/a | `string` | n/a | yes |

--- a/infra/resources/_modules/container_apps/com_cae.tf
+++ b/infra/resources/_modules/container_apps/com_cae.tf
@@ -1,6 +1,6 @@
 module "com_cae" {
   source  = "pagopa-dx/azure-container-app-environment/azurerm"
-  version = "~> 0.0"
+  version = "~> 1.0"
 
   resource_group_name = var.resource_group_name
 

--- a/infra/resources/_modules/container_apps/iam.tf
+++ b/infra/resources/_modules/container_apps/iam.tf
@@ -1,0 +1,22 @@
+resource "azurerm_role_assignment" "cae_admins_contributor" {
+  for_each = var.entra_id_admin_ids
+
+  role_definition_name = "Owner"
+  scope                = module.com_cae.id
+  principal_id         = each.value
+  description          = "Allow IO Admins to read Spring Dashboard"
+}
+
+resource "azurerm_key_vault_access_policy" "reminder_kv_messages" {
+  key_vault_id       = var.key_vault_id
+  secret_permissions = ["Get", "List"]
+  object_id          = module.com_cae.user_assigned_identity.principal_id
+  tenant_id          = var.tenant_id
+}
+
+resource "azurerm_role_assignment" "cae_acr_pull" {
+  role_definition_name = "AcrPull"
+  scope                = var.acr_id
+  principal_id         = module.com_cae.user_assigned_identity.principal_id
+  description          = "Allow Container Apps to pull images from ACR"
+}

--- a/infra/resources/_modules/container_apps/variables.tf
+++ b/infra/resources/_modules/container_apps/variables.tf
@@ -51,3 +51,13 @@ variable "key_vault_id" {
   type        = string
   description = "Id of the team domain key vault"
 }
+
+variable "entra_id_admin_ids" {
+  type        = set(string)
+  description = "Id of Entra ID groups that should be admins of the Container App Environment"
+}
+
+variable "acr_id" {
+  type        = string
+  description = "The Id of the ACR to pull images from"
+}

--- a/infra/resources/prod/README.md
+++ b/infra/resources/prod/README.md
@@ -50,10 +50,12 @@
 | [azurerm_role_assignment.infra_cd_rg_st_queue_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_rg_st_table_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_cd_rg_user_access_admin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.infra_cd_rgs_ca_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_ci_rg_cosmos_contributor](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_ci_rg_st_blob_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_ci_rg_st_queue_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_role_assignment.infra_ci_rg_st_table_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.infra_ci_rgs_ca_operator](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azuread_group.adgroup_com_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_com_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_io_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |

--- a/infra/resources/prod/README.md
+++ b/infra/resources/prod/README.md
@@ -56,8 +56,10 @@
 | [azurerm_role_assignment.infra_ci_rg_st_table_reader](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azuread_group.adgroup_com_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azuread_group.adgroup_com_devs](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.adgroup_io_admins](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azurerm_application_insights.common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/application_insights) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_container_registry.acr](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/container_registry) | data source |
 | [azurerm_cosmosdb_account.cosmos_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/cosmosdb_account) | data source |
 | [azurerm_cosmosdb_account.io_com_cosmos](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/cosmosdb_account) | data source |
 | [azurerm_key_vault.weu_common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |

--- a/infra/resources/prod/container_apps.tf
+++ b/infra/resources/prod/container_apps.tf
@@ -12,8 +12,15 @@ module "container_apps" {
   log_analytics_workspace_id = data.azurerm_application_insights.common.workspace_id
 
   key_vault_id = data.azurerm_key_vault.weu_messages.id
+  acr_id       = data.azurerm_container_registry.acr.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id
+
+  entra_id_admin_ids = [
+    data.azuread_group.adgroup_com_admins.object_id,
+    data.azuread_group.adgroup_com_devs.object_id,
+    data.azuread_group.adgroup_io_admins.object_id,
+  ]
 
   tags = local.tags
 }

--- a/infra/resources/prod/data.tf
+++ b/infra/resources/prod/data.tf
@@ -150,10 +150,19 @@ data "azurerm_user_assigned_identity" "app_cd_01" {
   resource_group_name = data.azurerm_resource_group.itn_messages.name
 }
 
+data "azuread_group" "adgroup_io_admins" {
+  display_name = "${local.project_legacy}-adgroup-admin"
+}
+
 data "azuread_group" "adgroup_com_admins" {
   display_name = "${local.project_legacy}-adgroup-com-admins"
 }
 
 data "azuread_group" "adgroup_com_devs" {
   display_name = "${local.project_legacy}-adgroup-com-developers"
+}
+
+data "azurerm_container_registry" "acr" {
+  name                = "iopcommonacr"
+  resource_group_name = "io-p-container-registry-rg"
 }

--- a/infra/resources/prod/resource_groups.tf
+++ b/infra/resources/prod/resource_groups.tf
@@ -55,6 +55,13 @@ resource "azurerm_role_assignment" "infra_ci_rg_st_table_reader" {
   description          = "Allow Infra CI identity to read Storage Account tables monorepository resource group scope"
 }
 
+resource "azurerm_role_assignment" "infra_ci_rgs_ca_operator" {
+  scope                = azurerm_resource_group.itn_com.id
+  role_definition_name = "Container Apps Operator"
+  principal_id         = data.azurerm_user_assigned_identity.infra_ci_01.principal_id
+  description          = "Allow Infra CI identity to read Container App configuration at monorepository resource group scope"
+}
+
 resource "azurerm_role_assignment" "infra_cd_rg_contributor" {
   scope                = azurerm_resource_group.itn_com.id
   role_definition_name = "Contributor"
@@ -95,6 +102,13 @@ resource "azurerm_role_assignment" "infra_cd_rg_st_table_contributor" {
   role_definition_name = "Storage Table Data Contributor"
   principal_id         = data.azurerm_user_assigned_identity.infra_cd_01.principal_id
   description          = "Allow Infra CD identity to write Storage Account tables monorepository resource group scope"
+}
+
+resource "azurerm_role_assignment" "infra_cd_rgs_ca_contributor" {
+  scope                = azurerm_resource_group.itn_com.id
+  role_definition_name = "Container Apps Contributor"
+  principal_id         = data.azurerm_user_assigned_identity.infra_cd_01.principal_id
+  description          = "Allow Infra CD identity to write Container App configuration at monorepository resource group scope"
 }
 
 resource "azurerm_role_assignment" "admins_group_rg" {

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -1,14 +1,13 @@
 {
-  "cosmos.io_com_cosmos_account": "25f24d7959907af82c19705c2ae425d9c10d48d5a5ebd36e1ef4c61e22a1d38b",
-  "cosmos.io_com_cosmos_account.naming_convention": "c71cfaa7ccaebb4dab588075d332bc788c21dc833f872218079e816c832aae69",
-  "eventhubs.etl": "0616d4d8be9b2415b169f76f7444238068c38848120f6271bfc19a35301eceb8",
+  "cosmos.io_com_cosmos_account": "6d42e6626d778d7096293964198b8cfd54032168f931b060930af1358f1c5504",
+  "eventhubs.etl": "9ba622aa606225513d2151f02e9ab8abe83605444dcb6dcfc572030088ad307a",
   "functions_messages_sending.function_app_messages_sending": "4c795dfe6da7624ff63814869dd8bd5bf00b129d9b593f40600f562b961ab8e2",
   "web_apps.etl_func": "4c795dfe6da7624ff63814869dd8bd5bf00b129d9b593f40600f562b961ab8e2",
   "web_apps.citizen_func": "4c795dfe6da7624ff63814869dd8bd5bf00b129d9b593f40600f562b961ab8e2",
   "storage_api_weu.com_st": "c073e41130034acebff0c22a7cffc22a1533ef46b64752789d472116abc21eee",
   "storage_api_weu.com_st.naming_convention": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
-  "web_apps.citizen_func_autoscaler": "88b6378ab8ade5820b81aa32e79b666d28d981db5c76e172df9976e88ab4e4aa",
-  "web_apps.etl_func_autoscaler": "88b6378ab8ade5820b81aa32e79b666d28d981db5c76e172df9976e88ab4e4aa",
-  "container_apps.com_cae": "1122d1e0de285bf73caceeba58ff45bf697ec05e6216af0076bd76c57fc50d97",
-  "container_apps.reminder_ca_itn_01": "bb709f5aef206397c0db16aeef2983d493ea1b3014bde9e778524846d69382e6"
+  "web_apps.citizen_func_autoscaler": "ec7ad56d62077d5136358c412c436b321a0706b03834b4023f0499701d0e3a9d",
+  "web_apps.etl_func_autoscaler": "ec7ad56d62077d5136358c412c436b321a0706b03834b4023f0499701d0e3a9d",
+  "container_apps.com_cae": "2a9399784d8f603bc9a43ad5334308832b7bae3c57280fb0ae418aaa3a70c5a0",
+  "container_apps.reminder_ca_itn_01": "f3df237af495ed6408eea7bef3ebb446f0a18698a2cf1cf554b47f3530c4c67f"
 }


### PR DESCRIPTION
Replace sample image with the real one for reminder app.

Few notes:
- Terraform does not allow to set the container app stack. Although it is not mandatory, it unlocks some stack-specific features. It currently supports java and dotnet only
- Gives `Owner` role to owners of this app. This role on CAE allows to browse [the dashboard](https://io-p-itn-com-dashboard-cae-01-azure-java.ext.bluesand-bdc6dc22.italynorth.azurecontainerapps.io) (accessible through authentication and from vnet only)
- Gives `AcrPull` role to the Container App to allow images pulling from the registry

Close CES-925