### PR TITLE
Update labeler workflow to use ubuntu-latest

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   labeler:
     name: PR Labeler
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
`ubuntu-20.04` was deprecated