### PR TITLE
Enforce Yarn Constraints

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,4 +1,5 @@
 preferReuse: true
+enableConstraintsChecks: true
 
 packageExtensions:
   "@azure/cosmos@*":

--- a/apps/ops-func/package.json
+++ b/apps/ops-func/package.json
@@ -8,7 +8,7 @@
     "build:watch": "yarn build --watch",
     "start": "func start",
     "format": "prettier --write .",
-    "lint": "eslint --fix src --ignore-pattern dist",
+    "lint": "eslint --fix src",
     "lint:check": "eslint src",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",


### PR DESCRIPTION
Enabled `yarn constraints` check on every `yarn install`, fix a constraint validation error.