### PR TITLE
Avoid creating new NH client for every operation

### DIFF
--- a/.changeset/wicked-words-grab.md
+++ b/.changeset/wicked-words-grab.md
@@ -1,0 +1,6 @@
+---
+"pushnotif-func": patch
+---
+
+- Use NH client factory to avoid building a new client on every function execution
+- Remove calls to legacy NH

--- a/apps/pushnotif-func/HandleNHCreateOrUpdateInstallationCallActivity/index.ts
+++ b/apps/pushnotif-func/HandleNHCreateOrUpdateInstallationCallActivity/index.ts
@@ -4,7 +4,7 @@ import { initTelemetryClient } from "../utils/appinsights";
 import { getConfigOrThrow } from "../utils/config";
 import { createActivity } from "../utils/durable/activities";
 import * as o from "../utils/durable/orchestrators";
-import { buildNHClient } from "../utils/notificationhubServicePartition";
+import { NotificationHubPartitionFactory } from "../utils/notificationhubServicePartition";
 import {
   ActivityInput,
   ActivityResultSuccess,
@@ -18,6 +18,10 @@ export const activityName = "HandleNHCreateOrUpdateInstallationCallActivity";
 const config = getConfigOrThrow();
 
 const telemetryClient = initTelemetryClient(config);
+
+const nhPatitionFactory = new NotificationHubPartitionFactory(
+  config.AZURE_NOTIFICATION_HUB_PARTITIONS,
+);
 
 /**
  * Build a `CreateOrUpdateActivity` to be called by an Orchestrator
@@ -38,7 +42,7 @@ const activityFunctionHandler = createActivity(
   activityName,
   ActivityInput,
   ActivityResultSuccess,
-  getActivityBody(buildNHClient, telemetryClient),
+  getActivityBody(nhPatitionFactory, telemetryClient),
 );
 
 export default activityFunctionHandler;

--- a/apps/pushnotif-func/HandleNHCreateOrUpdateInstallationCallOrchestrator/__tests__/handler.test.ts
+++ b/apps/pushnotif-func/HandleNHCreateOrUpdateInstallationCallOrchestrator/__tests__/handler.test.ts
@@ -5,7 +5,6 @@ import * as E from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getMockDeleteInstallationActivity } from "../../__mocks__/activities-mocks";
 import { context as contextMockBase } from "../../__mocks__/durable-functions";
 import { ActivityInput as CreateOrUpdateActivityInput } from "../../HandleNHCreateOrUpdateInstallationCallActivity";
 import {
@@ -23,7 +22,6 @@ import {
   failureActivity,
 } from "../../utils/durable/orchestrators";
 import { consumeGenerator } from "../../utils/durable/utils";
-import { NotificationHubConfig } from "../../utils/notificationhubServicePartition";
 import {
   NhCreateOrUpdateInstallationOrchestratorCallInput,
   getHandler,
@@ -55,15 +53,6 @@ const anOrchestratorInput =
     message: aCreateOrUpdateInstallationMessage,
   });
 
-const legacyNotificationHubConfig: NotificationHubConfig = {
-  AZURE_NH_ENDPOINT: "foo" as NonEmptyString,
-  AZURE_NH_HUB_NAME: "bar" as NonEmptyString,
-};
-const newNotificationHubConfig: NotificationHubConfig = {
-  AZURE_NH_ENDPOINT: "foo" as NonEmptyString,
-  AZURE_NH_HUB_NAME: "bar" as NonEmptyString,
-};
-
 type CallableCreateOrUpdateActivity =
   CallableActivity<CreateOrUpdateActivityInput>;
 
@@ -87,9 +76,6 @@ const contextMockWithDf = {
   },
 } as unknown as IOrchestrationFunctionContext;
 
-const mockDeleteInstallationActivitySuccess =
-  getMockDeleteInstallationActivity(success());
-
 describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -97,9 +83,6 @@ describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
   it("should start the activities with the right inputs", async () => {
     const orchestratorHandler = getHandler({
       createOrUpdateActivity: mockCreateOrUpdateActivity,
-      deleteInstallationActivity: mockDeleteInstallationActivitySuccess,
-      legacyNotificationHubConfig: legacyNotificationHubConfig,
-      notificationHubConfigPartitionChooser: () => newNotificationHubConfig,
     })(contextMockWithDf);
 
     const result = consumeGenerator(orchestratorHandler);
@@ -120,7 +103,6 @@ describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
             expect.any(Object),
             expect.objectContaining({
               installationId: aCreateOrUpdateInstallationMessage.installationId,
-              notificationHubConfig: legacyNotificationHubConfig,
               platform: aCreateOrUpdateInstallationMessage.platform,
               pushChannel: aCreateOrUpdateInstallationMessage.pushChannel,
               tags: aCreateOrUpdateInstallationMessage.tags,
@@ -134,14 +116,11 @@ describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
   it("should always call CreateOrUpdate activity with new NH parameters", async () => {
     const orchestratorHandler = getHandler({
       createOrUpdateActivity: mockCreateOrUpdateActivity,
-      deleteInstallationActivity: mockDeleteInstallationActivitySuccess,
-      legacyNotificationHubConfig: legacyNotificationHubConfig,
-      notificationHubConfigPartitionChooser: () => newNotificationHubConfig,
     })(contextMockWithDf);
 
     const result = consumeGenerator(orchestratorHandler);
 
-    expect.assertions(2);
+    expect.assertions(1);
 
     pipe(
       result,
@@ -157,18 +136,9 @@ describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
             expect.any(Object),
             expect.objectContaining({
               installationId: aCreateOrUpdateInstallationMessage.installationId,
-              notificationHubConfig: newNotificationHubConfig,
               platform: aCreateOrUpdateInstallationMessage.platform,
               pushChannel: aCreateOrUpdateInstallationMessage.pushChannel,
               tags: aCreateOrUpdateInstallationMessage.tags,
-            }),
-          );
-
-          expect(mockDeleteInstallationActivitySuccess).toBeCalledWith(
-            expect.any(Object),
-            expect.objectContaining({
-              installationId: aCreateOrUpdateInstallationMessage.installationId,
-              notificationHubConfig: legacyNotificationHubConfig,
             }),
           );
         },
@@ -189,9 +159,6 @@ describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
     try {
       const orchestratorHandler = getHandler({
         createOrUpdateActivity: mockCreateOrUpdateActivity,
-        deleteInstallationActivity: mockDeleteInstallationActivitySuccess,
-        legacyNotificationHubConfig: legacyNotificationHubConfig,
-        notificationHubConfigPartitionChooser: () => newNotificationHubConfig,
       })(contextMockWithDf);
 
       expect.assertions(2);
@@ -209,9 +176,6 @@ describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
 
     const orchestratorHandler = getHandler({
       createOrUpdateActivity: mockCreateOrUpdateActivity,
-      deleteInstallationActivity: mockDeleteInstallationActivitySuccess,
-      legacyNotificationHubConfig: legacyNotificationHubConfig,
-      notificationHubConfigPartitionChooser: () => newNotificationHubConfig,
     })(contextMockWithDf);
 
     expect.assertions(2);
@@ -230,9 +194,6 @@ describe("HandleNHCreateOrUpdateInstallationCallOrchestrator", () => {
 
     const orchestratorHandler = getHandler({
       createOrUpdateActivity: mockCreateOrUpdateActivity,
-      deleteInstallationActivity: mockDeleteInstallationActivitySuccess,
-      legacyNotificationHubConfig: legacyNotificationHubConfig,
-      notificationHubConfigPartitionChooser: () => newNotificationHubConfig,
     })(contextMockWithDf);
 
     expect.assertions(2);

--- a/apps/pushnotif-func/HandleNHCreateOrUpdateInstallationCallOrchestrator/index.ts
+++ b/apps/pushnotif-func/HandleNHCreateOrUpdateInstallationCallOrchestrator/index.ts
@@ -1,12 +1,7 @@
-﻿import * as df from "durable-functions";
+import * as df from "durable-functions";
 
 import { getCallableActivity as getCreateOrUpdateCallableActivity } from "../HandleNHCreateOrUpdateInstallationCallActivity";
-import { getCallableActivity as getDeleteInstallationCallableActivity } from "../HandleNHDeleteInstallationCallActivity";
 import { getConfigOrThrow } from "../utils/config";
-import {
-  getNHLegacyConfig,
-  getNotificationHubPartitionConfig,
-} from "../utils/notificationhubServicePartition";
 import { getHandler } from "./handler";
 
 const config = getConfigOrThrow();
@@ -16,20 +11,8 @@ const createOrUpdateActivity = getCreateOrUpdateCallableActivity({
   backoffCoefficient: 1.5,
 });
 
-const deleteInstallationActivity = getDeleteInstallationCallableActivity({
-  ...new df.RetryOptions(5000, config.RETRY_ATTEMPT_NUMBER),
-  backoffCoefficient: 1.5,
-});
-
-const legacyNotificationHubConfig = getNHLegacyConfig(config);
-const notificationHubConfigPartitionChooser =
-  getNotificationHubPartitionConfig(config);
-
 const handler = getHandler({
   createOrUpdateActivity,
-  deleteInstallationActivity,
-  legacyNotificationHubConfig,
-  notificationHubConfigPartitionChooser,
 });
 
 const orchestrator = df.orchestrator(handler);

--- a/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/__tests__/handler.test.ts
+++ b/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/__tests__/handler.test.ts
@@ -4,13 +4,11 @@ import { TelemetryClient } from "applicationinsights";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { context as contextMock } from "../../__mocks__/durable-functions";
-import { envConfig } from "../../__mocks__/env-config.mock";
 import { nhPartitionFactory } from "../../__mocks__/notification-hub";
 import {
   ActivityResultFailure,
   createActivity,
 } from "../../utils/durable/activities";
-import { NotificationHubConfig } from "../../utils/notificationhubServicePartition";
 import {
   ActivityInput,
   ActivityResultSuccess,
@@ -21,11 +19,6 @@ const aFiscalCodeHash =
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
 
 const anInstallationId = aFiscalCodeHash;
-
-const aNHConfig = {
-  AZURE_NH_ENDPOINT: envConfig.AZURE_NH_ENDPOINT,
-  AZURE_NH_HUB_NAME: envConfig.AZURE_NH_HUB_NAME,
-} as NotificationHubConfig;
 
 const mockTelemetryClient = {
   trackEvent: vi.fn().mockImplementation(() => {}),
@@ -52,7 +45,6 @@ describe("HandleNHDeleteInstallationCallActivity", () => {
 
     const input = ActivityInput.encode({
       installationId: anInstallationId,
-      notificationHubConfig: aNHConfig,
     });
     const res = await handler(contextMock, input);
     expect(
@@ -81,7 +73,6 @@ describe("HandleNHDeleteInstallationCallActivity", () => {
 
     const input = ActivityInput.encode({
       installationId: anInstallationId,
-      notificationHubConfig: aNHConfig,
     });
     const res = await handler(contextMock, input);
     expect(

--- a/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/handler.ts
+++ b/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/handler.ts
@@ -11,19 +11,15 @@ import {
   failActivity,
 } from "../utils/durable/activities";
 import { deleteInstallation } from "../utils/notification";
-import {
-  NotificationHubConfig,
-  NotificationHubPartitionFactory,
-} from "../utils/notificationhubServicePartition";
+import { NotificationHubPartitionFactory } from "../utils/notificationhubServicePartition";
 
 // Activity name for df
 export const ActivityName = "HandleNHDeleteInstallationCallActivity";
 
 // Activity input
 export type ActivityInput = t.TypeOf<typeof ActivityInput>;
-export const ActivityInput = t.interface({
+export const ActivityInput = t.type({
   installationId: NonEmptyString,
-  notificationHubConfig: NotificationHubConfig,
 });
 
 // Activity Result
@@ -32,7 +28,6 @@ export { ActivityResultSuccess } from "../utils/durable/activities";
 /**
  * For each Notification Hub Message of type "Delete" calls related Notification Hub service
  */
-
 export const getActivityBody =
   (
     nhPartitionFactory: NotificationHubPartitionFactory,
@@ -52,8 +47,6 @@ export const getActivityBody =
             properties: {
               installationId: input.installationId,
               isSuccess: "false",
-              notificationHubName:
-                input.notificationHubConfig.AZURE_NH_HUB_NAME,
               reason: e.message,
             },
             tagOverrides: { samplingEnabled: "false" },
@@ -66,8 +59,6 @@ export const getActivityBody =
             properties: {
               installationId: input.installationId,
               isSuccess: "true",
-              notificationHubName:
-                input.notificationHubConfig.AZURE_NH_HUB_NAME,
             },
             tagOverrides: { samplingEnabled: "false" },
           });

--- a/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/handler.ts
+++ b/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/handler.ts
@@ -1,4 +1,3 @@
-import { NotificationHubsClient } from "@azure/notification-hubs";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { TelemetryClient } from "applicationinsights";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -12,7 +11,10 @@ import {
   failActivity,
 } from "../utils/durable/activities";
 import { deleteInstallation } from "../utils/notification";
-import { NotificationHubConfig } from "../utils/notificationhubServicePartition";
+import {
+  NotificationHubConfig,
+  NotificationHubPartitionFactory,
+} from "../utils/notificationhubServicePartition";
 
 // Activity name for df
 export const ActivityName = "HandleNHDeleteInstallationCallActivity";
@@ -33,13 +35,13 @@ export { ActivityResultSuccess } from "../utils/durable/activities";
 
 export const getActivityBody =
   (
-    buildNHClient: (nhConfig: NotificationHubConfig) => NotificationHubsClient,
+    nhPartitionFactory: NotificationHubPartitionFactory,
     telemetryClient: TelemetryClient,
     // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   ): ActivityBody<ActivityInput, ActivityResultSuccess> =>
   ({ input, logger }) => {
     logger.info(`INSTALLATION_ID=${input.installationId}`);
-    const nhClient = buildNHClient(input.notificationHubConfig);
+    const nhClient = nhPartitionFactory.getPartition(input.installationId);
 
     return pipe(
       deleteInstallation(nhClient, input.installationId),

--- a/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/index.ts
+++ b/apps/pushnotif-func/HandleNHDeleteInstallationCallActivity/index.ts
@@ -4,7 +4,7 @@ import { initTelemetryClient } from "../utils/appinsights";
 import { getConfigOrThrow } from "../utils/config";
 import { createActivity } from "../utils/durable/activities";
 import * as o from "../utils/durable/orchestrators";
-import { buildNHClient } from "../utils/notificationhubServicePartition";
+import { NotificationHubPartitionFactory } from "../utils/notificationhubServicePartition";
 import {
   ActivityInput,
   ActivityResultSuccess,
@@ -17,6 +17,10 @@ export const activityName = "HandleNHDeleteInstallationCallActivity";
 
 const config = getConfigOrThrow();
 const telemetryClient = initTelemetryClient(config);
+
+const nhPatitionFactory = new NotificationHubPartitionFactory(
+  config.AZURE_NOTIFICATION_HUB_PARTITIONS,
+);
 
 /**
  * Build a `HandleNHDeleteInstallationCallActivity` to be called by an Orchestrator
@@ -37,7 +41,7 @@ const activityFunctionHandler = createActivity<ActivityInput>(
   activityName,
   ActivityInput,
   ActivityResultSuccess,
-  getActivityBody(buildNHClient, telemetryClient),
+  getActivityBody(nhPatitionFactory, telemetryClient),
 );
 
 export default activityFunctionHandler;

--- a/apps/pushnotif-func/HandleNHDeleteInstallationCallOrchestrator/index.ts
+++ b/apps/pushnotif-func/HandleNHDeleteInstallationCallOrchestrator/index.ts
@@ -2,10 +2,6 @@ import * as df from "durable-functions";
 
 import { getCallableActivity as getDeleteInstallationCallableActivity } from "../HandleNHDeleteInstallationCallActivity";
 import { getConfigOrThrow } from "../utils/config";
-import {
-  getNHLegacyConfig,
-  getNotificationHubPartitionConfig,
-} from "../utils/notificationhubServicePartition";
 import { getHandler } from "./handler";
 
 const config = getConfigOrThrow();
@@ -15,14 +11,8 @@ const deleteInstallationActivity = getDeleteInstallationCallableActivity({
   backoffCoefficient: 1.5,
 });
 
-const legacyNotificationHubConfig = getNHLegacyConfig(config);
-const notificationHubConfigPartitionChooser =
-  getNotificationHubPartitionConfig(config);
-
 const handler = getHandler({
   deleteInstallationActivity,
-  legacyNotificationHubConfig,
-  notificationHubConfigPartitionChooser,
 });
 const orchestrator = df.orchestrator(handler);
 

--- a/apps/pushnotif-func/HandleNHNotificationCall/handler.ts
+++ b/apps/pushnotif-func/HandleNHNotificationCall/handler.ts
@@ -30,16 +30,10 @@ const notifyMessage = (
   message: NotifyMessage,
 ): Promise<string> =>
   pipe(
-    ["current", "legacy"],
-    t.array(NhTarget).encode,
-    AR.map(T.of),
-    AR.map(
-      flow(
-        T.map((target) => NhNotifyMessageRequest.encode({ message, target })),
-        T.map((m) => Buffer.from(JSON.stringify(m)).toString("base64")),
-      ),
-    ),
-    T.sequenceArray,
+    NhTarget.encode("current"),
+    T.of,
+    T.map((target) => NhNotifyMessageRequest.encode({ message, target })),
+    T.map((m) => Buffer.from(JSON.stringify(m)).toString("base64")),
     T.map(
       (notifyMessages) => (context.bindings.notifyMessages = notifyMessages),
     ),

--- a/apps/pushnotif-func/HandleNHNotificationCall/handler.ts
+++ b/apps/pushnotif-func/HandleNHNotificationCall/handler.ts
@@ -1,9 +1,8 @@
 import { Context } from "@azure/functions";
 import * as df from "durable-functions";
 import { DurableOrchestrationClient } from "durable-functions/lib/src/durableorchestrationclient";
-import * as AR from "fp-ts/Array";
 import * as T from "fp-ts/Task";
-import { flow, pipe } from "fp-ts/lib/function";
+import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
 
 import { OrchestratorName as CreateOrUpdateInstallationOrchestrator } from "../HandleNHCreateOrUpdateInstallationCallOrchestrator/handler";

--- a/apps/pushnotif-func/HandleNHNotifyMessageCallActivityQueue/__tests__/handler.test.ts
+++ b/apps/pushnotif-func/HandleNHNotifyMessageCallActivityQueue/__tests__/handler.test.ts
@@ -138,15 +138,6 @@ describe("HandleNHNotifyMessageCallActivityQueue", () => {
   it("should trigger a retry if notify fails", async () => {
     vi.spyOn(
       NotificationHubsClient.prototype,
-      "getInstallation",
-    ).mockResolvedValueOnce({
-      installationId: aFiscalCodeHash,
-      platform: "apns",
-      pushChannel: "channel",
-    });
-
-    vi.spyOn(
-      NotificationHubsClient.prototype,
       "sendNotification",
     ).mockRejectedValueOnce({});
 

--- a/apps/pushnotif-func/HandleNHNotifyMessageCallActivityQueue/index.ts
+++ b/apps/pushnotif-func/HandleNHNotifyMessageCallActivityQueue/index.ts
@@ -2,28 +2,24 @@ import { AzureFunction, Context } from "@azure/functions";
 
 import { initTelemetryClient } from "../utils/appinsights";
 import { getConfigOrThrow } from "../utils/config";
-import {
-  getNHLegacyConfig,
-  getNotificationHubPartitionConfig,
-} from "../utils/notificationhubServicePartition";
+import { NotificationHubPartitionFactory } from "../utils/notificationhubServicePartition";
 import { NhNotifyMessageResponse, handle } from "./handler";
 
 const config = getConfigOrThrow();
 
 const telemetryClient = initTelemetryClient(config);
 
-const legacyNotificationHubConfig = getNHLegacyConfig(config);
-const notificationHubConfigPartitionChooser =
-  getNotificationHubPartitionConfig(config);
+const nhPatitionFactory = new NotificationHubPartitionFactory(
+  config.AZURE_NOTIFICATION_HUB_PARTITIONS,
+);
 
 export const index: AzureFunction = (
-  context: Context,
+  _: Context,
   notifyRequest: unknown,
 ): NhNotifyMessageResponse =>
   handle(
     notifyRequest,
-    legacyNotificationHubConfig,
-    notificationHubConfigPartitionChooser,
     config.FISCAL_CODE_NOTIFICATION_BLACKLIST,
     telemetryClient,
+    nhPatitionFactory,
   );

--- a/apps/pushnotif-func/__mocks__/notification-hub.ts
+++ b/apps/pushnotif-func/__mocks__/notification-hub.ts
@@ -1,0 +1,30 @@
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+
+import { NotificationHubPartitionFactory } from "../utils/notificationhubServicePartition";
+
+export const nhPartitionFactory = new NotificationHubPartitionFactory([
+  {
+    endpoint:
+      "Endpoint=sb://nh-1.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test;" as NonEmptyString,
+    name: "nh1" as NonEmptyString,
+    partitionRegex: new RegExp("^[0-3]"),
+  },
+  {
+    endpoint:
+      "Endpoint=sb://nh-2.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test;" as NonEmptyString,
+    name: "nh2" as NonEmptyString,
+    partitionRegex: new RegExp("^[4-7]"),
+  },
+  {
+    endpoint:
+      "Endpoint=sb://nh-3.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test;" as NonEmptyString,
+    name: "nh3" as NonEmptyString,
+    partitionRegex: new RegExp("^[8-b]"),
+  },
+  {
+    endpoint:
+      "Endpoint=sb://nh-4.servicebus.windows.net/;SharedAccessKeyName=test;SharedAccessKey=test;" as NonEmptyString,
+    name: "nh4" as NonEmptyString,
+    partitionRegex: new RegExp("^[c-f]"),
+  },
+]);

--- a/apps/pushnotif-func/utils/__tests__/notificationhubServicePartition.test.ts
+++ b/apps/pushnotif-func/utils/__tests__/notificationhubServicePartition.test.ts
@@ -1,27 +1,9 @@
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as E from "fp-ts/lib/Either";
 import { describe, expect, it } from "vitest";
 
-import { envConfig } from "../../__mocks__/env-config.mock";
 import { InstallationId } from "../../generated/notifications/InstallationId";
 import { NHClientError } from "../notification";
-import {
-  getNHLegacyConfig,
-  getNotificationHubPartitionConfig,
-  testShaForPartitionRegex,
-} from "../notificationhubServicePartition";
-
-const aFiscalCodeHash =
-  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
-
-describe("NotificationHubServicepartition", () => {
-  it("should return always NH0 Configuration", () => {
-    const nhConfig = getNHLegacyConfig(envConfig);
-
-    expect(nhConfig.AZURE_NH_ENDPOINT).toBe(envConfig.AZURE_NH_ENDPOINT);
-    expect(nhConfig.AZURE_NH_HUB_NAME).toBe(envConfig.AZURE_NH_HUB_NAME);
-  });
-});
+import { testShaForPartitionRegex } from "../notificationhubServicePartition";
 
 describe("NHClientError", () => {
   it("should decode a 404 as right", () => {
@@ -113,23 +95,5 @@ describe("Partition Regex", () => {
     expect(
       testShaForPartitionRegex(partition1Regex, invalidInstallationId),
     ).toBe(false);
-  });
-
-  it("should return right Notification Hub partition", () => {
-    const NH = getNotificationHubPartitionConfig(envConfig)(aFiscalCodeHash);
-
-    expect(NH.AZURE_NH_HUB_NAME).toBe(
-      envConfig.AZURE_NOTIFICATION_HUB_PARTITIONS[3].name,
-    );
-  });
-
-  it("should throw exception if no Notification Hub partition has been found", () => {
-    const fakeInstallationId = "hhhhhh" as InstallationId;
-
-    expect(() => {
-      getNotificationHubPartitionConfig(envConfig)(fakeInstallationId);
-    }).toThrowError(
-      `Unable to find Notification Hub partition for ${fakeInstallationId}`,
-    );
   });
 });

--- a/apps/pushnotif-func/utils/healthcheck.ts
+++ b/apps/pushnotif-func/utils/healthcheck.ts
@@ -3,7 +3,7 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 
-import { buildNHClient } from "./notificationhubServicePartition";
+import { NotificationHubPartitionFactory } from "./notificationhubServicePartition";
 
 /**
  * Check connections to Notification Hubs
@@ -11,16 +11,15 @@ import { buildNHClient } from "./notificationhubServicePartition";
  * @returns either true or an array of error messages
  */
 export const checkAzureNotificationHub = (
-  AZURE_NH_ENDPOINT: NonEmptyString,
-  AZURE_NH_HUB_NAME: NonEmptyString,
+  nhPartitionFactory: NotificationHubPartitionFactory,
+  installationId: NonEmptyString,
 ): healthcheck.HealthCheck<"AzureNotificationHub"> =>
   pipe(
     TE.tryCatch(
       () =>
-        buildNHClient({
-          AZURE_NH_ENDPOINT,
-          AZURE_NH_HUB_NAME,
-        }).deleteInstallation("aFakeInstallation"),
+        nhPartitionFactory
+          .getPartition(installationId)
+          .deleteInstallation(installationId),
       healthcheck.toHealthProblems("AzureNotificationHub" as const),
     ),
     TE.map(() => true),

--- a/apps/pushnotif-func/utils/notificationhubServicePartition.ts
+++ b/apps/pushnotif-func/utils/notificationhubServicePartition.ts
@@ -1,34 +1,10 @@
 import { NotificationHubsClient } from "@azure/notification-hubs";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import * as E from "fp-ts/lib/Either";
-import { pipe } from "fp-ts/lib/function";
-import * as t from "io-ts";
 
 import { InstallationId } from "../generated/notifications/InstallationId";
-import { IConfig } from "./config";
 import { DisjoitedNotificationHubPartitionArray } from "./types";
-import { string } from "fp-ts";
+
 import assert = require("node:assert");
-
-export const NotificationHubConfig = t.type({
-  AZURE_NH_ENDPOINT: NonEmptyString,
-  AZURE_NH_HUB_NAME: NonEmptyString,
-});
-
-export type NotificationHubConfig = t.TypeOf<typeof NotificationHubConfig>;
-
-/**
- * It returns the configuration related to the Legacy Notification Hub instance
- *
- * @param envConfig the env config, containing
- *                  `AZURE_NH_ENDPOINT` and `AZURE_NH_HUB_NAME` variables
- */
-export const getNHLegacyConfig = (
-  envConfig: IConfig,
-): NotificationHubConfig => ({
-  AZURE_NH_ENDPOINT: envConfig.AZURE_NH_ENDPOINT,
-  AZURE_NH_HUB_NAME: envConfig.AZURE_NH_HUB_NAME,
-});
 
 /**
  * @param sha The sha to test
@@ -39,41 +15,9 @@ export const testShaForPartitionRegex = (
   sha: InstallationId,
 ): boolean => (typeof regex === "string" ? new RegExp(regex) : regex).test(sha);
 
-/**
- * It returns the configuration related to one of the new Notification Hub instances
- * based on the partion mechanism defined
- *
- * @param envConfig the env config with Notification Hub connection strings and names
- * @param sha a valid hash256 representing a Fiscal Code
- */
-export const getNotificationHubPartitionConfig =
-  (envConfig: IConfig) =>
-  (sha: InstallationId): NotificationHubConfig =>
-    pipe(
-      envConfig.AZURE_NOTIFICATION_HUB_PARTITIONS.find((p) =>
-        testShaForPartitionRegex(p.partitionRegex, sha),
-      ),
-      E.fromNullable(
-        Error(`Unable to find Notification Hub partition for ${sha}`),
-      ),
-      E.map((partition) => ({
-        AZURE_NH_ENDPOINT: partition.endpoint,
-        AZURE_NH_HUB_NAME: partition.name,
-      })),
-      E.getOrElseW((e) => {
-        throw e;
-      }),
-    );
-
-export const buildNHClient = ({
-  AZURE_NH_ENDPOINT,
-  AZURE_NH_HUB_NAME,
-}: NotificationHubConfig): NotificationHubsClient =>
-  new NotificationHubsClient(AZURE_NH_ENDPOINT, AZURE_NH_HUB_NAME);
-
 export class NotificationHubPartitionFactory {
-  #m: Map<string, NotificationHubsClient>;
   #hash: (installationId: NonEmptyString) => string | undefined;
+  #m: Map<string, NotificationHubsClient>;
 
   constructor(partitions: DisjoitedNotificationHubPartitionArray) {
     this.#m = new Map(


### PR DESCRIPTION
- Create a single nh client when starting the function using a factory
- Remove calls to legacy NH (no more used)

Resolves IOCOM-2400