### PR TITLE
Change type on pushnotif package.json

### DIFF
--- a/apps/pushnotif-func/package.json
+++ b/apps/pushnotif-func/package.json
@@ -2,7 +2,7 @@
   "name": "pushnotif-func",
   "version": "1.0.3",
   "license": "MIT",
-  "type": "module",
+  "type": "commonjs",
   "scripts": {
     "build": "yarn generate && tsc",
     "start": "func start",


### PR DESCRIPTION
Type=module was accidentally committed. It is causing a runtime error regarding some module exports