### PR TITLE
Create new messages api to apim

### DIFF
--- a/infra/repository/tfmodules.lock.json
+++ b/infra/repository/tfmodules.lock.json
@@ -12,9 +12,9 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/github-environment-bootstrap/github/0.1.1"
   },
   "repo.github_runner": {
-    "hash": "faa85913e464fe631d12d4413d35862ce6d7ff510bfa1b5b7b064c1d8ee77766",
-    "version": "1.1.0",
+    "hash": "f61dee034958ff6b025aaa8cf687f742565efb1b506f25b35bdafc6bf1658ab7",
+    "version": "1.1.1",
     "name": "github_selfhosted_runner_on_container_app_jobs",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.1.0"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.1.1"
   }
 }

--- a/infra/resources/_modules/apim/README.md
+++ b/infra/resources/_modules/apim/README.md
@@ -22,9 +22,11 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azurerm_api_management_api.messages_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api) | resource |
 | [azurerm_api_management_api.messages_sending_external_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api) | resource |
 | [azurerm_api_management_api.messages_sending_internal_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api) | resource |
 | [azurerm_api_management_api.payments_updater_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api) | resource |
+| [azurerm_api_management_api_policy.messages_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
 | [azurerm_api_management_api_policy.messages_sending_external_api_v1_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
 | [azurerm_api_management_api_policy.messages_sending_internal_api_v1_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
 | [azurerm_api_management_api_policy.payments_updater_api_v1_policy](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_api_policy) | resource |
@@ -38,10 +40,12 @@ No modules.
 | [azurerm_api_management_group_user.payment_group_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group_user) | resource |
 | [azurerm_api_management_group_user.reminder_group_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_group_user) | resource |
 | [azurerm_api_management_named_value.io_p_itn_com_rc_func_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
+| [azurerm_api_management_named_value.io_p_itn_com_services_func_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.io_p_messages_sending_func_key_itn](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_named_value.paymentup_base_url](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_named_value) | resource |
 | [azurerm_api_management_product.apim_itn_product_notifications](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product) | resource |
 | [azurerm_api_management_product.apim_itn_product_payments](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product) | resource |
+| [azurerm_api_management_product_api.messages_api_v1](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
 | [azurerm_api_management_product_api.messages_sending_external_api_v1_product_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
 | [azurerm_api_management_product_api.messages_sending_internal_api_v1_product_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
 | [azurerm_api_management_product_api.payments_updater_api_v1_product_api](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management_product_api) | resource |
@@ -56,6 +60,7 @@ No modules.
 | [azurerm_api_management_product.apim_itn_product_services](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/api_management_product) | data source |
 | [azurerm_key_vault_secret.rc_func_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.sending_func_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.services_func_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [http_http.payment_updater_openapi](https://registry.terraform.io/providers/hashicorp/http/3.5.0/docs/data-sources/http) | data source |
 | [http_http.pushnotif_internal_openapi](https://registry.terraform.io/providers/hashicorp/http/3.5.0/docs/data-sources/http) | data source |
 | [http_http.remote_content_openapi](https://registry.terraform.io/providers/hashicorp/http/3.5.0/docs/data-sources/http) | data source |
@@ -71,6 +76,7 @@ No modules.
 | <a name="input_location"></a> [location](#input\_location) | One of westeurope, northeurope | `string` | n/a | yes |
 | <a name="input_location_short"></a> [location\_short](#input\_location\_short) | location\_short | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | n/a | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource group to deploy resources to | `string` | n/a | yes |
 
 ## Outputs
 

--- a/infra/resources/_modules/apim/api/messages/policy.xml
+++ b/infra/resources/_modules/apim/api/messages/policy.xml
@@ -1,0 +1,51 @@
+<policies>
+    <inbound>
+        <base />
+        <choose>
+            <when condition="@(context.User.Groups.Any(g => g.Name == "ApiAuthenticationClientCertificate") && !(context.Request.Headers.GetValueOrDefault("{{apigad-gad-client-certificate-verified-header}}", "false") == "true"))">
+                <return-response>
+                    <set-status code="403" reason="Invalid client certificate" />
+                </return-response>
+            </when>
+        </choose>
+        <set-backend-service base-url="https://io-p-itn-com-services-func-01.azurewebsites.net/api/v1" />
+        <set-header name="x-functions-key" exists-action="override">
+            <value>{{io-p-itn-com-services-func-key}}</value>
+        </set-header>
+        <set-header name="x-user-id" exists-action="override">
+            <value>@(context.User.Id)</value>
+        </set-header>
+        <set-header name="x-user-groups" exists-action="override">
+            <value>@(String.Join(",", context.User.Groups.Select(g => g.Name)))</value>
+        </set-header>
+        <set-header name="x-subscription-id" exists-action="override">
+            <value>@(context.Subscription.Id)</value>
+        </set-header>
+        <set-header name="x-user-email" exists-action="override">
+            <value>@(context.User.Email)</value>
+        </set-header>
+        <cors>
+            <allowed-origins>
+                <origin>*</origin>
+            </allowed-origins>
+            <allowed-methods>
+                <method>*</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>*</header>
+            </allowed-headers>
+            <expose-headers>
+                <header>*</header>
+            </expose-headers>
+        </cors>
+    </inbound>
+    <outbound>
+        <base />
+    </outbound>
+    <backend>
+        <base />
+    </backend>
+    <on-error>
+        <base />
+    </on-error>
+</policies>

--- a/infra/resources/_modules/apim/apim_namedvalues.tf
+++ b/infra/resources/_modules/apim/apim_namedvalues.tf
@@ -25,3 +25,12 @@ resource "azurerm_api_management_named_value" "io_p_itn_com_rc_func_key" {
   value               = data.azurerm_key_vault_secret.rc_func_key.value
   secret              = "true"
 }
+
+resource "azurerm_api_management_named_value" "io_p_itn_com_services_func_key" {
+  name                = "io-p-itn-com-services-func-key"
+  display_name        = "io-p-itn-com-services-func-key"
+  api_management_name = data.azurerm_api_management.apim_itn_api.name
+  resource_group_name = var.resource_group_name
+  value               = data.azurerm_key_vault_secret.services_func_key.value
+  secret              = "true"
+}

--- a/infra/resources/_modules/apim/data.tf
+++ b/infra/resources/_modules/apim/data.tf
@@ -2,3 +2,8 @@ data "azurerm_api_management" "apim_itn_api" {
   name                = local.apim_itn_name
   resource_group_name = local.apim_itn_resource_group_name
 }
+
+data "azurerm_key_vault_secret" "services_func_key" {
+  name         = "services-func-key"
+  key_vault_id = local.key_vault.id
+}

--- a/infra/resources/_modules/apim/services.tf
+++ b/infra/resources/_modules/apim/services.tf
@@ -41,3 +41,40 @@ resource "azurerm_api_management_product_api" "messages_sending_external_api_v1_
   api_management_name = data.azurerm_api_management.apim_itn_api.name
   resource_group_name = data.azurerm_api_management.apim_itn_api.resource_group_name
 }
+
+resource "azurerm_api_management_api" "messages_api_v1" {
+  name                = format("%s-%s-messages-api-01", local.product, var.location_short)
+  api_management_name = data.azurerm_api_management.apim_itn_api.name
+  resource_group_name = var.resource_group_name
+  revision            = "1"
+
+  description  = "IO Messages - API"
+  display_name = "IO Messages - API"
+
+  path      = "api/v1/messages"
+  protocols = ["https"]
+
+  subscription_required = true
+  service_url           = null
+
+  import {
+    content_format = "openapi-link"
+    //TODO: update the commit id once the PR is merged
+    content_value = "https://raw.githubusercontent.com/pagopa/io-messages/68a8b247b06206c14c11383089cce4e87d202c15/apps/services-func/openapi/index.yaml"
+  }
+}
+
+resource "azurerm_api_management_api_policy" "messages_api_v1" {
+  api_name            = azurerm_api_management_api.messages_api_v1.name
+  api_management_name = data.azurerm_api_management.apim_itn_api.name
+  resource_group_name = var.resource_group_name
+
+  xml_content = file("../_modules/apim/api/messages/policy.xml")
+}
+
+resource "azurerm_api_management_product_api" "messages_api_v1" {
+  product_id          = data.azurerm_api_management_product.apim_itn_product_services.product_id
+  api_name            = azurerm_api_management_api.messages_api_v1.name
+  api_management_name = data.azurerm_api_management.apim_itn_api.name
+  resource_group_name = var.resource_group_name
+}

--- a/infra/resources/_modules/apim/variables.tf
+++ b/infra/resources/_modules/apim/variables.tf
@@ -49,3 +49,8 @@ variable "key_vault" {
     id   = string
   })
 }
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group to deploy resources to"
+}

--- a/infra/resources/_modules/web_apps/README.md
+++ b/infra/resources/_modules/web_apps/README.md
@@ -27,6 +27,7 @@ No requirements.
 | <a name="module_remote_content_func"></a> [remote\_content\_func](#module\_remote\_content\_func) | pagopa-dx/azure-function-app/azurerm | ~> 0.0 |
 | <a name="module_remote_content_func_autoscaler"></a> [remote\_content\_func\_autoscaler](#module\_remote\_content\_func\_autoscaler) | pagopa-dx/azure-app-service-plan-autoscaler/azurerm | ~> 1.0 |
 | <a name="module_services_func"></a> [services\_func](#module\_services\_func) | pagopa-dx/azure-function-app/azurerm | ~> 1.0 |
+| <a name="module_services_func_autoscaler"></a> [services\_func\_autoscaler](#module\_services\_func\_autoscaler) | pagopa-dx/azure-app-service-plan-autoscaler/azurerm | ~> 1.0 |
 
 ## Resources
 

--- a/infra/resources/prod/apim.tf
+++ b/infra/resources/prod/apim.tf
@@ -7,6 +7,7 @@ module "apim" {
   location_short        = local.location_short
   legacy_location_short = local.legacy_location_short
   domain                = local.domain
+  resource_group_name   = azurerm_resource_group.itn_com.name
 
   key_vault = module.key_vaults.com
 }


### PR DESCRIPTION
Create a new messages api to apim associated to `io-services-api`.
This way all the calls to `/messages` are captured by this api and will be redirected to the new `services-func` microservice.

Closes IOCOM-2470