### PR TITLE
Bump azure-storage-account version

### DIFF
--- a/infra/repository/.terraform.lock.hcl
+++ b/infra/repository/.terraform.lock.hcl
@@ -56,6 +56,7 @@ provider "registry.terraform.io/hashicorp/null" {
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "h1:wTNrZnwQdOOT/TW9pa+7GgJeFK2OvTvDmx78VmUmZXM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",

--- a/infra/repository/tfmodules.lock.json
+++ b/infra/repository/tfmodules.lock.json
@@ -1,9 +1,9 @@
 {
   "repo": {
-    "hash": "a9c99a9c39837ea8dc12e81f85bd89b76093b877a231d2de0b65ca82b5ff6a51",
-    "version": "2.4.3",
+    "hash": "ff77962093ad5d7e8e4fe9f35cb33f55738b7de69bbced0376538f774b14c883",
+    "version": "2.4.4",
     "name": "azure_github_environment_bootstrap",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-github-environment-bootstrap/azurerm/2.4.3"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-github-environment-bootstrap/azurerm/2.4.4"
   },
   "repo.github_repository": {
     "hash": "0de1e4059b671876146afc11bb3ae899e55ea423887f64f02d66eacd2d0dfd11",
@@ -12,9 +12,9 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/github-environment-bootstrap/github/0.1.1"
   },
   "repo.github_runner": {
-    "hash": "f61dee034958ff6b025aaa8cf687f742565efb1b506f25b35bdafc6bf1658ab7",
-    "version": "1.1.1",
+    "hash": "fe5740c89e2c59f323b070dff0e4340cb0349655c6bf7c9e52238175641acad4",
+    "version": "1.1.2",
     "name": "github_selfhosted_runner_on_container_app_jobs",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.1.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/github-selfhosted-runner-on-container-app-jobs/azurerm/1.1.2"
   }
 }

--- a/infra/resources/_modules/storage_accounts/storage_account_io_com.tf
+++ b/infra/resources/_modules/storage_accounts/storage_account_io_com.tf
@@ -1,6 +1,6 @@
 module "com_st" {
   source  = "pagopa-dx/azure-storage-account/azurerm"
-  version = "0.0.9"
+  version = "1.0.1"
 
   subnet_pep_id       = var.subnet_pep_id
   tags                = var.tags

--- a/infra/resources/prod/.terraform.lock.hcl
+++ b/infra/resources/prod/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "3.4.0"
   constraints = "~> 3.0"
   hashes = [
+    "h1:D4wPDjiMNuWQcB1cYQIbS9M68QwQ2BQ8TdcamU3ig3k=",
     "h1:KeA9a60dssTVEFWkAuJ2lxztHyYB9bKmUfYanW2POSo=",
     "zh:035a6d6e6aa7f117969702873c27344ec4ddd88f676cebc1088316fb26d5c95a",
     "zh:11f86935174d8223699cae00b3a705ded1d75a4efb6d4723d3788f5446e1eaa5",
@@ -67,6 +68,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.4"
   hashes = [
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
+    "h1:wTNrZnwQdOOT/TW9pa+7GgJeFK2OvTvDmx78VmUmZXM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -24,16 +24,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-event-hub/azurerm/0.0.11"
   },
   "storage_api_weu.com_st": {
-    "hash": "c073e41130034acebff0c22a7cffc22a1533ef46b64752789d472116abc21eee",
-    "version": "0.0.9",
+    "hash": "a2a257b25753f91b36acef29e080efc4d62dea59e803f56e33e813e7a343e66b",
+    "version": "1.0.1",
     "name": "azure_storage_account",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/0.0.9"
-  },
-  "storage_api_weu.com_st.naming_convention": {
-    "hash": "5b1d21788783dcf33e17a9842f9f7c874c8c5f736c82e70979eb9c8785a74ce4",
-    "version": "0.0.5",
-    "name": "azure_naming_convention",
-    "source": "https://registry.terraform.io/modules/pagopa/dx-azure-naming-convention/azurerm/0.0.5"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-storage-account/azurerm/1.0.1"
   },
   "web_apps.citizen_func": {
     "hash": "367548c5df2a42f5273583c0de4181c865bd419a4d0aca3cffa2ba19a90c210a",


### PR DESCRIPTION
Bump pagopa-dx/azure-storage-account/azurerm version.
The old pagopa-dx/azure-storage-account/azurerm version is importing a wrong source for the azure-naming-convention module.