### PR TITLE
Update auth policy fragment to avoid plan diff

### DIFF
--- a/infra/resources/_modules/apim/fragment/session-fragment.xml
+++ b/infra/resources/_modules/apim/fragment/session-fragment.xml
@@ -1,17 +1,16 @@
 <fragment>
 	<!-- Extract the token from the Authorization Header -->
-  <set-variable name="token" value='@{
+  <set-variable name="token" value="@{
     string[] values;
     return context.Request.Headers.TryGetValue("Authorization", out values) ? values.FirstOrDefault() : "";
-  }' />
-
+  }" />
   <!-- Check if the Authorization header is valid, if not return 401 Unauthorized -->
   <choose>
-    <when condition='@(
+    <when condition="@(
       string.IsNullOrEmpty((string)context.Variables["token"]) ||
       !(((string)context.Variables["token"]).StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)) ||
       string.IsNullOrWhiteSpace(((string)context.Variables["token"]).Substring(7))
-    )'>
+    )">
       <set-header name="Content-Type" exists-action="override">
         <value>application/json</value>
       </set-header>
@@ -21,7 +20,6 @@
       </return-response>
   </when>
   </choose>
-
   <!-- Call the session manager, pasing the bearer token, to get the user identity -->
 	<send-request mode="new" response-variable-name="introspectionResponse" timeout="10" ignore-error="false">
 		<set-url>https://io-p-weu-session-manager-app-03.azurewebsites.net/api/auth/v1/user-identity</set-url>
@@ -33,12 +31,11 @@
       <value>@(((string)context.Variables["token"]))</value>
 		</set-header>
 	</send-request>
-
 	<choose>
     <!-- If 200 return set the x-user header as the base64 of the response -->
-		<when condition='@(((IResponse)context.Variables["introspectionResponse"]).StatusCode == 200)'>
+		<when condition="@(((IResponse)context.Variables["introspectionResponse"]).StatusCode == 200)">
 			<!-- Parse the introspectionResponse as a string -->
-			<set-variable name="userData" value='@(((IResponse)context.Variables["introspectionResponse"]).Body.As&lt;string&gt;())' />
+			<set-variable name="userData" value="@(((IResponse)context.Variables["introspectionResponse"]).Body.As&lt;string&gt;())" />
 			<!-- Remove the Authorization Header -->
 			<set-header name="Authorization" exists-action="delete" />
 			<!-- Set the x-user header with the user data -->
@@ -50,14 +47,12 @@
         )</value>
 			</set-header>
 		</when>
-
-		<when condition='@(((IResponse)context.Variables["introspectionResponse"]).StatusCode == 401)'>
+		<when condition="@(((IResponse)context.Variables["introspectionResponse"]).StatusCode == 401)">
 			<return-response response-variable-name="introspectionErrorResponse">
 				<set-status code="401" reason="Unauthorized" />
           <set-body>{"title": "Proxy Error", "status": 401, "detail": "Unauthorized"}</set-body>
 			</return-response>
 		</when>
-
 		<otherwise>
 			<set-header name="Content-Type" exists-action="override">
         <value>application/json</value>


### PR DESCRIPTION
Resolves a persistent false-positive diff on the `azurerm_api_management_policy_fragment` resource caused by inconsistencies between the policy XML format stored locally and the standardized format returned by the Azure API Management service.

The Terraform plan continually showed a difference in the value of the policy fragment because Azure API Management enforces a specific internal formatting (standardization of whitespace, line endings, and quoting) upon receiving the XML, which did not match the original formatting in our local session-fragment.xml file.

The issue was resolved by standardizing the formatting directly in the source XML file (session-fragment.xml) to match the format Azure returns.

