### PR TITLE
Use new redis into web_apps module

### DIFF
--- a/infra/resources/_modules/web_apps/etl_func.tf
+++ b/infra/resources/_modules/web_apps/etl_func.tf
@@ -163,14 +163,6 @@ resource "azurerm_key_vault_access_policy" "etl_func_kv_access_policy" {
   certificate_permissions = []
 }
 
-resource "azurerm_redis_cache_access_policy_assignment" "etl_func_redis_access_policy" {
-  name               = "etl_func"
-  redis_cache_id     = var.redis_cache.id
-  access_policy_name = "Data Contributor"
-  object_id          = module.etl_func.function_app.function_app.principal_id
-  object_id_alias    = "ServicePrincipal"
-}
-
 output "etl_func" {
   value = {
     id                   = module.etl_func.function_app.function_app.id

--- a/infra/resources/prod/web_apps.tf
+++ b/infra/resources/prod/web_apps.tf
@@ -47,10 +47,10 @@ module "web_apps" {
   }
 
   redis_cache = {
-    id         = azurerm_redis_cache.com.id
-    hostname   = azurerm_redis_cache.com.hostname
-    port       = azurerm_redis_cache.com.ssl_port
-    access_key = azurerm_redis_cache.com.primary_access_key
+    id         = azurerm_redis_cache.com_new.id
+    hostname   = azurerm_redis_cache.com_new.hostname
+    port       = azurerm_redis_cache.com_new.ssl_port
+    access_key = azurerm_redis_cache.com_new.primary_access_key
   }
 
   application_insights = {


### PR DESCRIPTION
- Use the new `io-p-itn-com-redis-02` for the `web_apps`
- Remove useless `azurerm_redis_cache_access_policy_assignment` for the `etl-func`

Closes IOCOM-2646