### PR TITLE
Revert "Set header x-pagopa-pn-io-src mandatory"

### DIFF
--- a/.changeset/floppy-brooms-nail.md
+++ b/.changeset/floppy-brooms-nail.md
@@ -1,0 +1,5 @@
+---
+"send-func": patch
+---
+
+revert send api mandatory header

--- a/apps/send-func/src/__mocks__/notification.ts
+++ b/apps/send-func/src/__mocks__/notification.ts
@@ -182,11 +182,6 @@ export const aSendHeaders = sendHeadersSchema.parse({
   ...aLollipopHeaders,
 });
 
-export const aSendHeadersWithoutSrc = sendHeadersSchema.parse({
-  "x-pagopa-cx-taxid": aFiscalCode,
-  ...aLollipopHeaders,
-});
-
 export const aCIEValidationdata = CIEValidationDataSchema.parse({
   mrtdData: {
     dg1: "dg1",

--- a/apps/send-func/src/adapters/functions/__tests__/aar-attachments.test.ts
+++ b/apps/send-func/src/adapters/functions/__tests__/aar-attachments.test.ts
@@ -68,7 +68,6 @@ describe("GetAttachment", () => {
       params: { attachmentUrl: anEncodedAttachmentUrl },
       url: "http://localhost",
     });
-    request.headers.set("x-pagopa-pn-io-src", "QR_CODE");
 
     await expect(
       getAttachmentHandler(request, context, aLollipopHeaders),
@@ -109,7 +108,6 @@ describe("GetAttachment", () => {
       query: { mandateId: anIvalidMandateId },
       url: "http://localhost",
     });
-    request.headers.set("x-pagopa-pn-io-src", "QR_CODE");
 
     await expect(
       getAttachmentHandler(request, context, aLollipopHeaders),
@@ -127,7 +125,6 @@ describe("GetAttachment", () => {
       params: { attachmentUrl: anEncodedInvalidAttachmentUrl },
       url: "http://localhost",
     });
-    request2.headers.set("x-pagopa-pn-io-src", "QR_CODE");
 
     await expect(
       getAttachmentHandler(request2, context, aLollipopHeaders),
@@ -140,29 +137,6 @@ describe("GetAttachment", () => {
       status: 400,
     });
 
-    expect(telemetryTrackEventMock).not.toHaveBeenCalled();
-  });
-
-  it("returns 400 status code if the x-pagopa-pn-io-src header is not set", async () => {
-    const request = new HttpRequest({
-      method: "GET",
-      params: { attachmentUrl: anEncodedAttachmentUrl },
-      query: { mandateId: anIvalidMandateId },
-      url: "http://localhost",
-    });
-
-    await expect(
-      getAttachmentHandler(request, context, aLollipopHeaders),
-    ).resolves.toEqual({
-      jsonBody: {
-        detail: "Missing mandatory x-pagopa-pn-io-src header",
-        status: 400,
-        title: "Bad Request",
-      },
-      status: 400,
-    });
-
-    expect(executeSpy).not.toHaveBeenCalled();
     expect(telemetryTrackEventMock).not.toHaveBeenCalled();
   });
 
@@ -183,7 +157,6 @@ describe("GetAttachment", () => {
       params: { attachmentUrl: anEncodedAttachmentUrl },
       url: "http://localhost",
     });
-    request.headers.set("x-pagopa-pn-io-src", "QR_CODE");
 
     await expect(
       getAttachmentHandler(request, context, aLollipopHeaders),

--- a/apps/send-func/src/adapters/functions/__tests__/aar-notifications.test.ts
+++ b/apps/send-func/src/adapters/functions/__tests__/aar-notifications.test.ts
@@ -49,7 +49,6 @@ describe("GetAARNotification", () => {
       params: { iun: aIun },
       url: "http://localhost",
     });
-    request.headers.set("x-pagopa-pn-io-src", "QR_CODE");
 
     await expect(handler(request, context, aLollipopHeaders)).resolves.toEqual({
       jsonBody: aThirdPartyMessage,
@@ -85,7 +84,6 @@ describe("GetAARNotification", () => {
       query: { mandateId: anIvalidMandateId },
       url: "http://localhost",
     });
-    request.headers.set("x-pagopa-pn-io-src", "QR_CODE");
 
     await expect(handler(request, context, aLollipopHeaders)).resolves.toEqual({
       jsonBody: {
@@ -95,27 +93,6 @@ describe("GetAARNotification", () => {
       },
       status: 400,
     });
-    expect(telemetryTrackEventMock).not.toHaveBeenCalled();
-  });
-
-  it("returns 400 status code if the x-pagopa-pn-io-src header is not set", async () => {
-    const request = new HttpRequest({
-      method: "GET",
-      params: { iun: aIun },
-      query: { mandateId: anIvalidMandateId },
-      url: "http://localhost",
-    });
-
-    await expect(handler(request, context, aLollipopHeaders)).resolves.toEqual({
-      jsonBody: {
-        detail: "Missing mandatory x-pagopa-pn-io-src header",
-        status: 400,
-        title: "Bad Request",
-      },
-      status: 400,
-    });
-
-    expect(getNotifiationExecuteSpy).not.toHaveBeenCalled();
     expect(telemetryTrackEventMock).not.toHaveBeenCalled();
   });
 
@@ -131,7 +108,6 @@ describe("GetAARNotification", () => {
       params: { iun: aIun },
       url: "http://localhost",
     });
-    request.headers.set("x-pagopa-pn-io-src", "QR_CODE");
 
     await expect(handler(request, context, aLollipopHeaders)).resolves.toEqual({
       jsonBody: aProblem,

--- a/apps/send-func/src/adapters/functions/__tests__/aar-qrcode-check.test.ts
+++ b/apps/send-func/src/adapters/functions/__tests__/aar-qrcode-check.test.ts
@@ -2,7 +2,7 @@ import {
   aCheckQrMandateResponse,
   aLollipopHeaders,
   aProblem,
-  aSendHeadersWithoutSrc,
+  aSendHeaders,
   anAarQrCodeValue,
   anInvalidAarQrCodeValue,
   mockNotificationClient,
@@ -64,7 +64,7 @@ describe("AARQrCodeCheck", () => {
 
     expect(qrCodeCheckExecuteSpy).toHaveBeenCalledWith(
       false,
-      aSendHeadersWithoutSrc,
+      aSendHeaders,
       anAarQrCodeValue,
     );
 

--- a/apps/send-func/src/adapters/functions/aar-attachments.ts
+++ b/apps/send-func/src/adapters/functions/aar-attachments.ts
@@ -33,19 +33,11 @@ export const getAttachment =
     context: InvocationContext,
     lollipopHeaders: LollipopHeaders,
   ): Promise<AarGetAttachmentResponse> => {
-    const ioSrcHeader = request.headers.get("x-pagopa-pn-io-src");
-    if (!ioSrcHeader) {
-      return malformedBodyResponse(
-        "Missing mandatory x-pagopa-pn-io-src header",
-        "Bad Request",
-      );
-    }
-
     const isTest = request.query.get("isTest") === "true";
 
     const sendHeaders = {
       "x-pagopa-cx-taxid": lollipopHeaders["x-pagopa-lollipop-user-id"],
-      "x-pagopa-pn-io-src": ioSrcHeader,
+      "x-pagopa-pn-io-src": "QR_CODE",
       ...lollipopHeaders,
     };
 

--- a/apps/send-func/src/adapters/functions/aar-notifications.ts
+++ b/apps/send-func/src/adapters/functions/aar-notifications.ts
@@ -22,19 +22,11 @@ export const getNotification =
     context: InvocationContext,
     lollipopHeaders: LollipopHeaders,
   ): Promise<AarGetNotificationResponse> => {
-    const ioSrcHeader = request.headers.get("x-pagopa-pn-io-src");
-    if (!ioSrcHeader) {
-      return malformedBodyResponse(
-        "Missing mandatory x-pagopa-pn-io-src header",
-        "Bad Request",
-      );
-    }
-
     const isTest = request.query.get("isTest") === "true";
 
     const sendHeaders = {
       "x-pagopa-cx-taxid": lollipopHeaders["x-pagopa-lollipop-user-id"],
-      "x-pagopa-pn-io-src": ioSrcHeader,
+      "x-pagopa-pn-io-src": "QR_CODE",
       ...lollipopHeaders,
     };
 

--- a/apps/send-func/src/adapters/functions/aar-qrcode-check.ts
+++ b/apps/send-func/src/adapters/functions/aar-qrcode-check.ts
@@ -30,6 +30,7 @@ export const aarQRCodeCheck =
     const isTest = request.query.get("isTest") === "true";
     const sendHeaders = {
       "x-pagopa-cx-taxid": lollipopHeaders["x-pagopa-lollipop-user-id"],
+      "x-pagopa-pn-io-src": "QR_CODE",
       ...lollipopHeaders,
     };
 


### PR DESCRIPTION
This reverts the change that made the x-pagopa-pn-io-src header mandatory from the app