### PR TITLE
Improve services-func local testability

### DIFF
--- a/apps/services-func/local.settings.json.example
+++ b/apps/services-func/local.settings.json.example
@@ -27,7 +27,7 @@
     "NOTIFY_API_KEY": "apiKey",
     "NODE_ENV": "dev",
     "MAILHOG_HOSTNAME": "mailhog",
-    "APIM_BASE_URL": "http://localhost",
+    "APIM_BASE_URL": "http://localhost:8007",
     "FF_PAYMENT_STATUS_ENABLED": true,
     "FF_DISABLE_INCOMPLETE_SERVICES": "none"
   },

--- a/bruno/services-func/CreateGenericMessage.bru
+++ b/bruno/services-func/CreateGenericMessage.bru
@@ -5,13 +5,13 @@ meta {
 }
 
 post {
-  url: {{services_func_url}}/api/v1/messages/{{fiscal_code}}
+  url: {{services_func_url}}/api/v1/messages/LVTEST00A00A199X
   body: json
   auth: none
 }
 
 headers {
-  x-user-groups: {{user_groups}}
+  x-user-groups: ApiMessageWrite
   x-user-email: {{sender_email}}
   x-subscription-id: {{sender_subscription_id}}
   x-user-id: {{sender_user_id}}
@@ -25,9 +25,4 @@ body:json {
       "markdown": "Body of a test message, this should be at least 80 chars long, otherwise you will obtain 400"
     }
   }
-}
-
-vars:pre-request {
-  fiscal_code: LVTEST00A00A199X
-  user_groups: ApiMessageWrite
 }

--- a/bruno/services-func/CreatePaymentMessage.bru
+++ b/bruno/services-func/CreatePaymentMessage.bru
@@ -5,13 +5,13 @@ meta {
 }
 
 post {
-  url: {{services_func_url}}/api/v1/messages/{{fiscal_code}}
+  url: {{services_func_url}}/api/v1/messages/LVTEST00A00A199X
   body: json
   auth: none
 }
 
 headers {
-  x-user-groups: {{user_groups}}
+  x-user-groups: ApiMessageWrite,ApiMessageWriteWithPayee
   x-user-email: {{sender_email}}
   x-subscription-id: {{sender_subscription_id}}
   x-user-id: {{sender_user_id}}
@@ -33,9 +33,4 @@ body:json {
       }
     }
   }
-}
-
-vars:pre-request {
-  fiscal_code: LVTEST00A00A199X
-  user_groups: ApiMessageWrite,ApiMessageWriteWithPayee
 }

--- a/bruno/services-func/CreatePremiumMessage.bru
+++ b/bruno/services-func/CreatePremiumMessage.bru
@@ -5,13 +5,13 @@ meta {
 }
 
 post {
-  url: {{services_func_url}}/api/v1/messages/{{fiscal_code}}
+  url: {{services_func_url}}/api/v1/messages/LVTEST00A00A199X
   body: json
   auth: none
 }
 
 headers {
-  x-user-groups: {{user_groups}}
+  x-user-groups: ApiMessageWrite,ApiMessageWriteAdvanced
   x-user-email: {{sender_email}}
   x-subscription-id: {{sender_subscription_id}}
   x-user-id: {{sender_user_id}}
@@ -26,9 +26,4 @@ body:json {
     },
     "feature_level_type": "ADVANCED"
   }
-}
-
-vars:pre-request {
-  fiscal_code: LVTEST00A00A199X
-  user_groups: ApiMessageWrite,ApiMessageWriteAdvanced
 }

--- a/bruno/services-func/CreateRCMessage.bru
+++ b/bruno/services-func/CreateRCMessage.bru
@@ -5,13 +5,13 @@ meta {
 }
 
 post {
-  url: {{services_func_url}}/api/v1/messages/{{fiscal_code}}
+  url: {{services_func_url}}/api/v1/messages/LVTEST00A00A199X
   body: json
   auth: none
 }
 
 headers {
-  x-user-groups: {{user_groups}}
+  x-user-groups: ApiMessageWrite,ApiThirdPartyMessageWrite
   x-user-email: {{sender_email}}
   x-subscription-id: {{sender_subscription_id}}
   x-user-id: {{sender_user_id}}
@@ -35,9 +35,4 @@ body:json {
       }
     }
   }
-}
-
-vars:pre-request {
-  fiscal_code: LVTEST00A00A199X
-  user_groups: ApiMessageWrite,ApiThirdPartyMessageWrite
 }

--- a/bruno/services-func/GetMessage.bru
+++ b/bruno/services-func/GetMessage.bru
@@ -5,21 +5,15 @@ meta {
 }
 
 get {
-  url: {{services_func_url}}/api/v1/messages/{{fiscal_code}}/{{message_id}}
+  url: {{services_func_url}}/api/v1/messages/LVTEST00A00A199X/01KEVCKA2JRX2XZ4DWXTYYM6CW
   body: none
   auth: inherit
 }
 
 headers {
-  x-user-groups: {{user_groups}}
+  x-user-groups: ApiMessageRead,ApiMessageReadAdvanced
   x-user-email: {{sender_email}}
   x-subscription-id: {{sender_subscription_id}}
   x-user-id: {{sender_user_id}}
   x-forwarded-for: {{receipt_id}}
-}
-
-vars:pre-request {
-  fiscal_code: LVTEST00A00A199X
-  user_groups: ApiMessageRead,ApiMessageReadAdvanced
-  message_id: 01K1Z982NQB2KZ431CWGXD44CR
 }

--- a/compose.yml
+++ b/compose.yml
@@ -73,6 +73,14 @@ services:
     volumes:
       - "./mockoon/session-manager.json:/data:readonly"
 
+  mock-server-apim:
+    image: mockoon/cli:latest@sha256:80c4acd9517840b6574784d420de2dc97a8b750d21b6a4b573d042d21e4833ba
+    command: ["--data", "data", "--port", "3000"]
+    ports:
+      - "8007:3000"
+    volumes:
+      - "./mockoon/apim.json:/data:readonly"
+
   mock-server-send:
     image: mockoon/cli:latest@sha256:80c4acd9517840b6574784d420de2dc97a8b750d21b6a4b573d042d21e4833ba
     command: ["--data", "data", "--port", "3000"]

--- a/mockoon/apim.json
+++ b/mockoon/apim.json
@@ -1,0 +1,94 @@
+{
+  "uuid": "1a131e9e-8aaa-4cfd-9ffd-484a5e7c99b3",
+  "lastMigration": 33,
+  "name": "Apim",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3000,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "20874de3-79e9-45c8-a2b5-bfe8d2b2bb70",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/v1/messages-sending/remote-contents/configurations/01ARZ3NDEKTSV4RRFFQ69G5FAV",
+      "responses": [
+        {
+          "uuid": "3da508c5-a2a7-412c-bf72-144d6b0fafd8",
+          "body": "{\n  \"configuration_id\": \"01ARZ3NDEKTSV4RRFFQ69G5FAV\",\n  \"description\": \"A new RC Configuration fortesting purpose\",\n  \"disable_lollipop_for\": [],\n  \"has_precondition\": \"NEVER\",\n  \"id\": \"01ARZ3NDEKTSV4RRFFQ69G5FAV\",\n  \"is_lollipop_enabled\": false,\n  \"name\": \"Updated configuration\",\n  \"user_id\": \"01JR0QRJ8MX1PD06DE6X5FWXS5\",\n  \"test_users\": [],\n  \"prod_environment\": {\n    \"base_url\": \"string\",\n    \"details_authentication\": {\n      \"header_key_name\": \"string\",\n      \"key\": \"string\",\n      \"type\": \"API-KEY\"\n    }\n  }\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "20874de3-79e9-45c8-a2b5-bfe8d2b2bb70"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
+}


### PR DESCRIPTION
- [Create apim mock with mockoon](https://github.com/pagopa/io-messages/commit/52113817577c79f7895bf1fc203f7e9420f118bd)
- [Remove redundant bruno variables](https://github.com/pagopa/io-messages/commit/620d8bf2ee87bff07bac0409aeaaa345dfddb57f)

NB: For the moment this mock only handles the happy path of the
getRCConfiguration call, this can be extended in future.