### PR TITLE
Add telemetry to lollipop middleware package

### DIFF
--- a/.changeset/tasty-beds-occur.md
+++ b/.changeset/tasty-beds-occur.md
@@ -1,0 +1,6 @@
+---
+"io-messages-common": minor
+"send-func": patch
+---
+
+Add telemetry to the lollipop middleware

--- a/apps/send-func/src/func.ts
+++ b/apps/send-func/src/func.ts
@@ -60,7 +60,10 @@ const main = async (config: Config): Promise<void> => {
     config.lollipop.apiKey,
     config.lollipop.baseUrl,
   );
-  const lollipopMiddleware = createLollipopMiddleware(lollipopClient);
+  const lollipopMiddleware = createLollipopMiddleware(
+    lollipopClient,
+    telemetryService,
+  );
 
   app.http("Health", {
     authLevel: "anonymous",

--- a/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
@@ -18,7 +18,7 @@ import { parseLollipopHeaders } from "../lollipop-middleware.js";
 
 const createMockRequest = (
   headers: Record<string, string>,
-  path: string = "/api/v1/messages",
+  path = "/api/v1/messages",
 ): HttpRequest =>
   new HttpRequest({
     headers: headers,
@@ -209,7 +209,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 403 }),
     );
   });
 
@@ -235,7 +235,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 403 }),
     );
   });
 
@@ -261,7 +261,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 403 }),
     );
   });
 
@@ -286,7 +286,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 403 }),
     );
   });
 
@@ -311,7 +311,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 403 }),
     );
   });
 });
@@ -341,7 +341,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 401 }),
     );
   });
 
@@ -389,7 +389,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 401 }),
     );
   });
 
@@ -413,7 +413,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 401 }),
     );
   });
 });
@@ -448,7 +448,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 403 }),
     );
   });
 
@@ -477,7 +477,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 401 }),
     );
   });
 
@@ -499,7 +499,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 403 }),
     );
   });
 });
@@ -600,7 +600,7 @@ describe("LollipopClient errors", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
-      expect.objectContaining({ status: 500, requestPath: "/api/v1/messages" }),
+      expect.objectContaining({ requestPath: "/api/v1/messages", status: 500 }),
     );
   });
 

--- a/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
@@ -16,11 +16,14 @@ import {
 import LollipopClient, { LollipopClientError } from "../lollipop-client.js";
 import { parseLollipopHeaders } from "../lollipop-middleware.js";
 
-const createMockRequest = (headers: Record<string, string>): HttpRequest =>
+const createMockRequest = (
+  headers: Record<string, string>,
+  path: string = "/api/v1/messages",
+): HttpRequest =>
   new HttpRequest({
     headers: headers,
     method: "POST",
-    url: "https://api.example.com/test",
+    url: `https://api.example.com${path}`,
   });
 
 const createValidUserIdentity = (assertionRef?: string) => ({
@@ -206,7 +209,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403 }),
+      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -232,7 +235,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403 }),
+      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -258,7 +261,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403 }),
+      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -283,7 +286,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403 }),
+      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -308,7 +311,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403 }),
+      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
     );
   });
 });
@@ -338,7 +341,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401 }),
+      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -386,7 +389,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401 }),
+      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -410,7 +413,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401 }),
+      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
     );
   });
 });
@@ -445,7 +448,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403 }),
+      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -474,7 +477,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 401 }),
+      expect.objectContaining({ status: 401, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -496,7 +499,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      expect.objectContaining({ status: 403 }),
+      expect.objectContaining({ status: 403, requestPath: "/api/v1/messages" }),
     );
   });
 });
@@ -597,7 +600,7 @@ describe("LollipopClient errors", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
-      expect.objectContaining({ status: 500 }),
+      expect.objectContaining({ status: 500, requestPath: "/api/v1/messages" }),
     );
   });
 
@@ -623,6 +626,7 @@ describe("LollipopClient errors", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_GENERIC_SERVER_ERROR,
+      { requestPath: "/api/v1/messages" },
     );
   });
 });

--- a/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
@@ -9,20 +9,19 @@ import { MiddlewareError } from "../../middleware.js";
 import {
   aFiscalCode,
   aSignatureInput,
+  aThumbprint,
   anAssertionRef,
   anLcParams,
-  aThumbprint,
 } from "../__mocks__/lollipop.js";
 import LollipopClient, { LollipopClientError } from "../lollipop-client.js";
 import { parseLollipopHeaders } from "../lollipop-middleware.js";
 
-const createMockRequest = (headers: Record<string, string>): HttpRequest => {
-  return new HttpRequest({
-    url: "https://api.example.com/test",
-    method: "POST",
+const createMockRequest = (headers: Record<string, string>): HttpRequest =>
+  new HttpRequest({
     headers: headers,
+    method: "POST",
+    url: "https://api.example.com/test",
   });
-};
 
 const createValidUserIdentity = (assertionRef?: string) => ({
   assertion_ref: assertionRef,
@@ -42,7 +41,7 @@ const createValidLollipopHeaders = (
   "x-pagopa-lollipop-original-url": "https://api.example.com/endpoint",
 });
 
-describe("parseLollipopHeaders", () => {
+describe("parseLollipopHeaders successful parsing", () => {
   let mockLollipopClient: LollipopClient;
   let mockTelemetryService: TelemetryService;
 
@@ -56,599 +55,661 @@ describe("parseLollipopHeaders", () => {
     };
   });
 
-  describe("successful parsing", () => {
-    it("should successfully parse valid lollipop headers with sha256 algorithm", async () => {
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
+  it("should successfully parse valid lollipop headers with sha256 algorithm", async () => {
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
-
-      const result = await parseLollipopHeaders(
-        req,
-        mockLollipopClient,
-        mockTelemetryService,
-      );
-
-      expect(result).toEqual({
-        signature: "sig1=:mockSignature:",
-        "signature-input": aSignatureInput,
-        "x-pagopa-lollipop-assertion-ref": anLcParams.assertion_ref,
-        "x-pagopa-lollipop-assertion-type": anLcParams.assertion_type,
-        "x-pagopa-lollipop-auth-jwt": anLcParams.lc_authentication_bearer,
-        "x-pagopa-lollipop-original-method": "POST",
-        "x-pagopa-lollipop-original-url": "https://api.example.com/endpoint",
-        "x-pagopa-lollipop-public-key": anLcParams.pub_key,
-        "x-pagopa-lollipop-user-id": aFiscalCode,
-      });
-
-      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
-        anAssertionRef,
-        expect.any(String), // operationId
-      );
-      expect(mockTelemetryService.trackEvent).not.toHaveBeenCalled();
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
     });
 
-    it("should successfully parse headers with sha384 algorithm", async () => {
-      const sha384Thumbprint =
-        "abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzab5678cdef";
-      const sha384AssertionRef = `sha384-${sha384Thumbprint}`;
-      const sha384SignatureInput = `sig1=(); keyid="${sha384Thumbprint}"; nonce="test-nonce-123"`;
+    const result = await parseLollipopHeaders(
+      req,
+      mockLollipopClient,
+      mockTelemetryService,
+    );
 
-      const userIdentity = createValidUserIdentity(sha384AssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(sha384SignatureInput),
-        "x-user": userHeader,
-      });
-
-      const lcParams = { ...anLcParams, assertion_ref: sha384AssertionRef };
-      vi.mocked(mockLollipopClient.generateLCParams).mockResolvedValue(
-        lcParams,
-      );
-
-      const result = await parseLollipopHeaders(
-        req,
-        mockLollipopClient,
-        mockTelemetryService,
-      );
-
-      expect(result["x-pagopa-lollipop-assertion-ref"]).toBe(
-        sha384AssertionRef,
-      );
-      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
-        sha384AssertionRef,
-        "test-nonce-123",
-      );
+    expect(result).toEqual({
+      signature: "sig1=:mockSignature:",
+      "signature-input": aSignatureInput,
+      "x-pagopa-lollipop-assertion-ref": anLcParams.assertion_ref,
+      "x-pagopa-lollipop-assertion-type": anLcParams.assertion_type,
+      "x-pagopa-lollipop-auth-jwt": anLcParams.lc_authentication_bearer,
+      "x-pagopa-lollipop-original-method": "POST",
+      "x-pagopa-lollipop-original-url": "https://api.example.com/endpoint",
+      "x-pagopa-lollipop-public-key": anLcParams.pub_key,
+      "x-pagopa-lollipop-user-id": aFiscalCode,
     });
 
-    it("should successfully parse headers with sha512 algorithm", async () => {
-      const sha512Thumbprint =
-        "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890123456789";
-      const sha512AssertionRef = `sha512-${sha512Thumbprint}`;
-      const sha512SignatureInput = `sig1=(); keyid="${sha512Thumbprint}"`;
-
-      const userIdentity = createValidUserIdentity(sha512AssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(sha512SignatureInput),
-        "x-user": userHeader,
-      });
-
-      const lcParams = { ...anLcParams, assertion_ref: sha512AssertionRef };
-      vi.mocked(mockLollipopClient.generateLCParams).mockResolvedValue(
-        lcParams,
-      );
-
-      const result = await parseLollipopHeaders(
-        req,
-        mockLollipopClient,
-        mockTelemetryService,
-      );
-
-      expect(result["x-pagopa-lollipop-assertion-ref"]).toBe(
-        sha512AssertionRef,
-      );
-    });
-
-    it("should generate a ULID as operationId when nonce is not present in signature-input", async () => {
-      const signatureInputWithoutNonce = `sig1=(); keyid="${aThumbprint}"`;
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(signatureInputWithoutNonce),
-        "x-user": userHeader,
-      });
-
-      await parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService);
-
-      // Verify that generateLCParams was called with a valid operationId (ULID format)
-      const operationId = vi.mocked(mockLollipopClient.generateLCParams).mock
-        .calls[0][1];
-      expect(operationId).toBeTruthy();
-      expect(typeof operationId).toBe("string");
-      expect(operationId.length).toBe(26); // ULID length
-    });
+    expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+      anAssertionRef,
+      expect.any(String),
+    );
+    expect(mockTelemetryService.trackEvent).not.toHaveBeenCalled();
   });
 
-  describe("invalid request headers", () => {
-    it("should throw MiddlewareError when lollipop request headers are missing", async () => {
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
+  it("should successfully parse headers with sha384 algorithm", async () => {
+    const sha384Thumbprint =
+      "abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzab5678cdef";
+    const sha384AssertionRef = `sha384-${sha384Thumbprint}`;
+    const sha384SignatureInput = `sig1=(); keyid="${sha384Thumbprint}"; nonce="test-nonce-123"`;
 
-      const req = createMockRequest({
-        "x-user": userHeader,
-        // Missing lollipop headers
-      });
+    const userIdentity = createValidUserIdentity(sha384AssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(
-        new MiddlewareError(
-          "Missing or invalid required lollipop headers",
-          403,
-        ),
-      );
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 403 },
-      );
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(sha384SignatureInput),
+      "x-user": userHeader,
     });
 
-    it("should throw MiddlewareError when signature header is missing", async () => {
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
+    const lcParams = { ...anLcParams, assertion_ref: sha384AssertionRef };
+    vi.mocked(mockLollipopClient.generateLCParams).mockResolvedValue(lcParams);
 
-      const { signature, ...headersWithoutSignature } =
-        createValidLollipopHeaders();
+    const result = await parseLollipopHeaders(
+      req,
+      mockLollipopClient,
+      mockTelemetryService,
+    );
 
-      const req = createMockRequest({
-        ...headersWithoutSignature,
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(MiddlewareError);
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 403 },
-      );
-    });
-
-    it("should throw MiddlewareError when signature-input header is missing", async () => {
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const {
-        "signature-input": signatureInput,
-        ...headersWithoutSignatureInput
-      } = createValidLollipopHeaders();
-
-      const req = createMockRequest({
-        ...headersWithoutSignatureInput,
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(MiddlewareError);
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 403 },
-      );
-    });
-
-    it("should throw MiddlewareError when x-pagopa-lollipop-original-method is missing", async () => {
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const {
-        "x-pagopa-lollipop-original-method": method,
-        ...headersWithoutMethod
-      } = createValidLollipopHeaders();
-
-      const req = createMockRequest({
-        ...headersWithoutMethod,
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(MiddlewareError);
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 403 },
-      );
-    });
-
-    it("should throw MiddlewareError when x-pagopa-lollipop-original-url is missing", async () => {
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const { "x-pagopa-lollipop-original-url": url, ...headersWithoutUrl } =
-        createValidLollipopHeaders();
-
-      const req = createMockRequest({
-        ...headersWithoutUrl,
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(MiddlewareError);
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 403 },
-      );
-    });
+    expect(result["x-pagopa-lollipop-assertion-ref"]).toBe(sha384AssertionRef);
+    expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+      sha384AssertionRef,
+      "test-nonce-123",
+    );
   });
 
-  describe("invalid x-user header", () => {
-    it("should throw MiddlewareError when x-user header is missing", async () => {
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-      });
+  it("should successfully parse headers with sha512 algorithm", async () => {
+    const sha512Thumbprint =
+      "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890123456789";
+    const sha512AssertionRef = `sha512-${sha512Thumbprint}`;
+    const sha512SignatureInput = `sig1=(); keyid="${sha512Thumbprint}"`;
 
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(new MiddlewareError("Missing x-user header", 401));
+    const userIdentity = createValidUserIdentity(sha512AssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 401 },
-      );
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(sha512SignatureInput),
+      "x-user": userHeader,
     });
 
-    it("should throw MiddlewareError when x-user header is not valid base64", async () => {
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": "not-valid-base64!@#",
-      });
+    const lcParams = { ...anLcParams, assertion_ref: sha512AssertionRef };
+    vi.mocked(mockLollipopClient.generateLCParams).mockResolvedValue(lcParams);
 
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow();
-    });
+    const result = await parseLollipopHeaders(
+      req,
+      mockLollipopClient,
+      mockTelemetryService,
+    );
 
-    it("should throw MiddlewareError when x-user header contains invalid JSON", async () => {
-      const invalidJson = Buffer.from("not valid json").toString("base64");
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": invalidJson,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow();
-    });
-
-    it("should throw MiddlewareError when user identity is invalid", async () => {
-      const invalidUserIdentity = {
-        // Missing required fields
-        fiscal_code: aFiscalCode,
-      };
-      const userHeader = Buffer.from(
-        JSON.stringify(invalidUserIdentity),
-      ).toString("base64");
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(MiddlewareError);
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 401 },
-      );
-    });
-
-    it("should throw MiddlewareError when fiscal_code is invalid", async () => {
-      const invalidUserIdentity = {
-        ...createValidUserIdentity(anAssertionRef),
-        fiscal_code: "INVALID",
-      };
-      const userHeader = Buffer.from(
-        JSON.stringify(invalidUserIdentity),
-      ).toString("base64");
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(MiddlewareError);
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 401 },
-      );
-    });
+    expect(result["x-pagopa-lollipop-assertion-ref"]).toBe(sha512AssertionRef);
   });
 
-  describe("assertion_ref validation", () => {
-    it("should throw MiddlewareError when assertion_ref is missing", async () => {
-      const userIdentity = createValidUserIdentity(); // No assertion_ref
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
+  it("should generate a ULID as operationId when nonce is not present in signature-input", async () => {
+    const signatureInputWithoutNonce = `sig1=(); keyid="${aThumbprint}"`;
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(new MiddlewareError("AssertionRef is missing", 403));
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 403 },
-      );
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(signatureInputWithoutNonce),
+      "x-user": userHeader,
     });
 
-    it("should throw MiddlewareError when assertion_ref has invalid format", async () => {
-      // Create a user identity with an invalid assertion_ref that won't match any schema
-      const invalidUserIdentity = {
-        assertion_ref: `sha1-${aThumbprint}`, // sha1 is not supported
-        date_of_birth: "1997-10-06",
-        family_name: "Rossi",
-        fiscal_code: aFiscalCode,
-        name: "Mario",
-        spid_level: "https://www.spid.gov.it/SpidL2",
-      };
-      const userHeader = Buffer.from(
-        JSON.stringify(invalidUserIdentity),
-      ).toString("base64");
+    await parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService);
 
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
+    const operationId = vi.mocked(mockLollipopClient.generateLCParams).mock
+      .calls[0][1];
+    expect(operationId).toBeTruthy();
+    expect(typeof operationId).toBe("string");
+    expect(operationId.length).toBe(26);
+  });
+});
 
-      // This will fail at user identity validation because sha1 format is not valid
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(MiddlewareError);
+describe("parseLollipopHeaders invalid request headers", () => {
+  let mockLollipopClient: LollipopClient;
+  let mockTelemetryService: TelemetryService;
 
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 401 },
-      );
-    });
+  beforeEach(() => {
+    mockLollipopClient = {
+      generateLCParams: vi.fn().mockResolvedValue(anLcParams),
+    } as unknown as LollipopClient;
 
-    it("should throw MiddlewareError when assertion_ref doesn't match algo-thumbprint format", async () => {
-      const mismatchedAssertionRef = `sha256-wrongThumbprint`;
-      const userIdentity = createValidUserIdentity(mismatchedAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(new MiddlewareError("AssertionRef mismatch", 403));
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-        { status: 403 },
-      );
-    });
+    mockTelemetryService = {
+      trackEvent: vi.fn(),
+    };
   });
 
-  describe("signature-input validation", () => {
-    it("should throw MiddlewareError when keyid is invalid in signature-input", async () => {
-      const invalidSignatureInput = `sig1=(); keyid="invalid!@#$%"`;
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
+  it("should throw MiddlewareError when lollipop request headers are missing", async () => {
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(invalidSignatureInput),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(
-        new MiddlewareError("Invalid keyid in signature-input", 500),
-      );
+    const req = createMockRequest({
+      "x-user": userHeader,
+      // Missing lollipop headers
     });
 
-    it("should throw MiddlewareError when keyid is missing in signature-input", async () => {
-      const noKeyidSignatureInput = `sig1=(); nonce="test"`;
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(
+      new MiddlewareError("Missing or invalid required lollipop headers", 403),
+    );
 
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(noKeyidSignatureInput),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(
-        new MiddlewareError("Invalid keyid in signature-input", 500),
-      );
-    });
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 403 },
+    );
   });
 
-  describe("LollipopClient errors", () => {
-    it("should throw MiddlewareError when LollipopClient.generateLCParams fails with LollipopClientError", async () => {
-      const clientError = new LollipopClientError(
-        "Error generating LC params",
-        { detail: "Internal error", status: 500 },
-      );
-      vi.mocked(mockLollipopClient.generateLCParams).mockRejectedValue(
-        clientError,
-      );
+  it("should throw MiddlewareError when signature header is missing", async () => {
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow(
-        expect.objectContaining({
-          message: "Error generating LC params",
-          status: 500,
-          body: { detail: "Internal error", status: 500 },
-        }),
-      );
-
-      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
-        TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
-        { status: 500 },
-      );
+    const headers = createValidLollipopHeaders();
+    const req = createMockRequest({
+      "signature-input": headers["signature-input"],
+      "x-pagopa-lollipop-original-method":
+        headers["x-pagopa-lollipop-original-method"],
+      "x-pagopa-lollipop-original-url":
+        headers["x-pagopa-lollipop-original-url"],
+      "x-user": userHeader,
     });
 
-    it("should throw generic Error when LollipopClient.generateLCParams fails with unexpected error", async () => {
-      const unexpectedError = new Error("Network error");
-      vi.mocked(mockLollipopClient.generateLCParams).mockRejectedValue(
-        unexpectedError,
-      );
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(MiddlewareError);
 
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
-
-      await expect(
-        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
-      ).rejects.toThrow("Unexpected Middleware error | Error: Network error");
-
-      expect(mockTelemetryService.trackEvent).not.toHaveBeenCalled();
-    });
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 403 },
+    );
   });
 
-  describe("edge cases", () => {
-    it("should handle signature-input with nonce containing special characters", async () => {
-      const specialNonce = "test-nonce-with-special_chars.123";
-      const signatureInput = `sig1=(); keyid="${aThumbprint}"; nonce="${specialNonce}"`;
+  it("should throw MiddlewareError when signature-input header is missing", async () => {
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
-
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(signatureInput),
-        "x-user": userHeader,
-      });
-
-      await parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService);
-
-      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
-        anAssertionRef,
-        specialNonce,
-      );
+    const headers = createValidLollipopHeaders();
+    const req = createMockRequest({
+      signature: headers.signature,
+      "x-pagopa-lollipop-original-method":
+        headers["x-pagopa-lollipop-original-method"],
+      "x-pagopa-lollipop-original-url":
+        headers["x-pagopa-lollipop-original-url"],
+      "x-user": userHeader,
     });
 
-    it("should handle signature-input with parameters in different order", async () => {
-      const signatureInput = `sig1=(); nonce="test"; keyid="${aThumbprint}"`;
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(MiddlewareError);
 
-      const userIdentity = createValidUserIdentity(anAssertionRef);
-      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
-        "base64",
-      );
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 403 },
+    );
+  });
 
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(signatureInput),
-        "x-user": userHeader,
-      });
+  it("should throw MiddlewareError when x-pagopa-lollipop-original-method is missing", async () => {
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      const result = await parseLollipopHeaders(
-        req,
-        mockLollipopClient,
-        mockTelemetryService,
-      );
-
-      expect(result).toBeDefined();
-      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
-        anAssertionRef,
-        "test",
-      );
+    const headers = createValidLollipopHeaders();
+    const req = createMockRequest({
+      signature: headers.signature,
+      "signature-input": headers["signature-input"],
+      "x-pagopa-lollipop-original-url":
+        headers["x-pagopa-lollipop-original-url"],
+      "x-user": userHeader,
     });
 
-    it("should handle optional user identity fields", async () => {
-      const userIdentityWithOptionals = {
-        ...createValidUserIdentity(anAssertionRef),
-        session_tracking_id: "session-123",
-        spid_email: "test@example.com",
-        spid_idp: "testIdp",
-      };
-      const userHeader = Buffer.from(
-        JSON.stringify(userIdentityWithOptionals),
-      ).toString("base64");
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(MiddlewareError);
 
-      const req = createMockRequest({
-        ...createValidLollipopHeaders(),
-        "x-user": userHeader,
-      });
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 403 },
+    );
+  });
 
-      const result = await parseLollipopHeaders(
-        req,
-        mockLollipopClient,
-        mockTelemetryService,
-      );
+  it("should throw MiddlewareError when x-pagopa-lollipop-original-url is missing", async () => {
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
 
-      expect(result).toBeDefined();
-      expect(result["x-pagopa-lollipop-user-id"]).toBe(aFiscalCode);
+    const headers = createValidLollipopHeaders();
+    const req = createMockRequest({
+      signature: headers.signature,
+      "signature-input": headers["signature-input"],
+      "x-pagopa-lollipop-original-method":
+        headers["x-pagopa-lollipop-original-method"],
+      "x-user": userHeader,
     });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(MiddlewareError);
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 403 },
+    );
+  });
+});
+
+describe("parseLollipopHeaders invalid x-user header", () => {
+  let mockLollipopClient: LollipopClient;
+  let mockTelemetryService: TelemetryService;
+
+  beforeEach(() => {
+    mockLollipopClient = {
+      generateLCParams: vi.fn().mockResolvedValue(anLcParams),
+    } as unknown as LollipopClient;
+
+    mockTelemetryService = {
+      trackEvent: vi.fn(),
+    };
+  });
+
+  it("should throw MiddlewareError when x-user header is missing", async () => {
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(new MiddlewareError("Missing x-user header", 401));
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 401 },
+    );
+  });
+
+  it("should throw MiddlewareError when x-user header is not valid base64", async () => {
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": "not-valid-base64!@#",
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow();
+  });
+
+  it("should throw MiddlewareError when x-user header contains invalid JSON", async () => {
+    const invalidJson = Buffer.from("not valid json").toString("base64");
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": invalidJson,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow();
+  });
+
+  it("should throw MiddlewareError when user identity is invalid", async () => {
+    const invalidUserIdentity = {
+      // Missing required fields
+      fiscal_code: aFiscalCode,
+    };
+    const userHeader = Buffer.from(
+      JSON.stringify(invalidUserIdentity),
+    ).toString("base64");
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(MiddlewareError);
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 401 },
+    );
+  });
+
+  it("should throw MiddlewareError when fiscal_code is invalid", async () => {
+    const invalidUserIdentity = {
+      ...createValidUserIdentity(anAssertionRef),
+      fiscal_code: "INVALID",
+    };
+    const userHeader = Buffer.from(
+      JSON.stringify(invalidUserIdentity),
+    ).toString("base64");
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(MiddlewareError);
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 401 },
+    );
+  });
+});
+
+describe("parseLollipopHeaders assertion_ref validation", () => {
+  let mockLollipopClient: LollipopClient;
+  let mockTelemetryService: TelemetryService;
+
+  beforeEach(() => {
+    mockLollipopClient = {
+      generateLCParams: vi.fn().mockResolvedValue(anLcParams),
+    } as unknown as LollipopClient;
+
+    mockTelemetryService = {
+      trackEvent: vi.fn(),
+    };
+  });
+  it("should throw MiddlewareError when assertion_ref is missing", async () => {
+    const userIdentity = createValidUserIdentity(); // No assertion_ref
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(new MiddlewareError("AssertionRef is missing", 403));
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 403 },
+    );
+  });
+
+  it("should throw MiddlewareError when assertion_ref has invalid format", async () => {
+    // Create a user identity with an invalid assertion_ref that won't match any schema
+    const invalidUserIdentity = {
+      assertion_ref: `sha1-${aThumbprint}`, // sha1 is not supported
+      date_of_birth: "1997-10-06",
+      family_name: "Rossi",
+      fiscal_code: aFiscalCode,
+      name: "Mario",
+      spid_level: "https://www.spid.gov.it/SpidL2",
+    };
+    const userHeader = Buffer.from(
+      JSON.stringify(invalidUserIdentity),
+    ).toString("base64");
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(MiddlewareError);
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 401 },
+    );
+  });
+
+  it("should throw MiddlewareError when assertion_ref doesn't match algo-thumbprint format", async () => {
+    const mismatchedAssertionRef = `sha256-wrongThumbprint`;
+    const userIdentity = createValidUserIdentity(mismatchedAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(new MiddlewareError("AssertionRef mismatch", 403));
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+      { status: 403 },
+    );
+  });
+});
+
+describe("parseLollipopHeaders signature-input validation", () => {
+  let mockLollipopClient: LollipopClient;
+  let mockTelemetryService: TelemetryService;
+
+  beforeEach(() => {
+    mockLollipopClient = {
+      generateLCParams: vi.fn().mockResolvedValue(anLcParams),
+    } as unknown as LollipopClient;
+
+    mockTelemetryService = {
+      trackEvent: vi.fn(),
+    };
+  });
+  it("should throw MiddlewareError when keyid is invalid in signature-input", async () => {
+    const invalidSignatureInput = `sig1=(); keyid="invalid!@#$%"`;
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(invalidSignatureInput),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(
+      new MiddlewareError("Invalid keyid in signature-input", 500),
+    );
+  });
+
+  it("should throw MiddlewareError when keyid is missing in signature-input", async () => {
+    const noKeyidSignatureInput = `sig1=(); nonce="test"`;
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(noKeyidSignatureInput),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(
+      new MiddlewareError("Invalid keyid in signature-input", 500),
+    );
+  });
+});
+
+describe("LollipopClient errors", () => {
+  let mockLollipopClient: LollipopClient;
+  let mockTelemetryService: TelemetryService;
+
+  beforeEach(() => {
+    mockLollipopClient = {
+      generateLCParams: vi.fn().mockResolvedValue(anLcParams),
+    } as unknown as LollipopClient;
+
+    mockTelemetryService = {
+      trackEvent: vi.fn(),
+    };
+  });
+  it("should throw MiddlewareError when LollipopClient.generateLCParams fails with LollipopClientError", async () => {
+    const clientError = new LollipopClientError("Error generating LC params", {
+      detail: "Internal error",
+      status: 500,
+    });
+    vi.mocked(mockLollipopClient.generateLCParams).mockRejectedValue(
+      clientError,
+    );
+
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow(
+      expect.objectContaining({
+        body: { detail: "Internal error", status: 500 },
+        message: "Error generating LC params",
+        status: 500,
+      }),
+    );
+
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
+      { status: 500 },
+    );
+  });
+
+  it("should throw generic Error when LollipopClient.generateLCParams fails with unexpected error", async () => {
+    const unexpectedError = new Error("Network error");
+    vi.mocked(mockLollipopClient.generateLCParams).mockRejectedValue(
+      unexpectedError,
+    );
+
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    await expect(
+      parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+    ).rejects.toThrow("Unexpected Middleware error | Error: Network error");
+
+    expect(mockTelemetryService.trackEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("parseLollipopHeaders edge cases", () => {
+  let mockLollipopClient: LollipopClient;
+  let mockTelemetryService: TelemetryService;
+
+  beforeEach(() => {
+    mockLollipopClient = {
+      generateLCParams: vi.fn().mockResolvedValue(anLcParams),
+    } as unknown as LollipopClient;
+
+    mockTelemetryService = {
+      trackEvent: vi.fn(),
+    };
+  });
+
+  it("should handle signature-input with nonce containing special characters", async () => {
+    const specialNonce = "test-nonce-with-special_chars.123";
+    const signatureInput = `sig1=(); keyid="${aThumbprint}"; nonce="${specialNonce}"`;
+
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(signatureInput),
+      "x-user": userHeader,
+    });
+
+    await parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService);
+
+    expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+      anAssertionRef,
+      specialNonce,
+    );
+  });
+
+  it("should handle signature-input with parameters in different order", async () => {
+    const signatureInput = `sig1=(); nonce="test"; keyid="${aThumbprint}"`;
+
+    const userIdentity = createValidUserIdentity(anAssertionRef);
+    const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+      "base64",
+    );
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(signatureInput),
+      "x-user": userHeader,
+    });
+
+    const result = await parseLollipopHeaders(
+      req,
+      mockLollipopClient,
+      mockTelemetryService,
+    );
+
+    expect(result).toBeDefined();
+    expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+      anAssertionRef,
+      "test",
+    );
+  });
+
+  it("should handle optional user identity fields", async () => {
+    const userIdentityWithOptionals = {
+      ...createValidUserIdentity(anAssertionRef),
+      session_tracking_id: "session-123",
+      spid_email: "test@example.com",
+      spid_idp: "testIdp",
+    };
+    const userHeader = Buffer.from(
+      JSON.stringify(userIdentityWithOptionals),
+    ).toString("base64");
+
+    const req = createMockRequest({
+      ...createValidLollipopHeaders(),
+      "x-user": userHeader,
+    });
+
+    const result = await parseLollipopHeaders(
+      req,
+      mockLollipopClient,
+      mockTelemetryService,
+    );
+
+    expect(result).toBeDefined();
+    expect(result["x-pagopa-lollipop-user-id"]).toBe(aFiscalCode);
   });
 });

--- a/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
@@ -1,0 +1,654 @@
+import { HttpRequest } from "@azure/functions";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  TelemetryEventName,
+  TelemetryService,
+} from "../../../domain/telemetry.js";
+import { MiddlewareError } from "../../middleware.js";
+import {
+  aFiscalCode,
+  aSignatureInput,
+  anAssertionRef,
+  anLcParams,
+  aThumbprint,
+} from "../__mocks__/lollipop.js";
+import LollipopClient, { LollipopClientError } from "../lollipop-client.js";
+import { parseLollipopHeaders } from "../lollipop-middleware.js";
+
+// Helper to create a mock HttpRequest
+const createMockRequest = (headers: Record<string, string>): HttpRequest => {
+  const headersMap = new Map(Object.entries(headers));
+  return {
+    headers: headersMap,
+  } as unknown as HttpRequest;
+};
+
+// Helper to create a valid user identity
+const createValidUserIdentity = (assertionRef?: string) => ({
+  assertion_ref: assertionRef,
+  date_of_birth: "1997-10-06",
+  family_name: "Rossi",
+  fiscal_code: aFiscalCode,
+  name: "Mario",
+  spid_level: "https://www.spid.gov.it/SpidL2",
+});
+
+// Helper to create valid lollipop request headers
+const createValidLollipopHeaders = (signatureInput?: string) => ({
+  signature: "sig1=:mockSignature:",
+  "signature-input": signatureInput || aSignatureInput,
+  "x-pagopa-lollipop-original-method": "POST",
+  "x-pagopa-lollipop-original-url": "https://api.example.com/endpoint",
+});
+
+describe("parseLollipopHeaders", () => {
+  let mockLollipopClient: LollipopClient;
+  let mockTelemetryService: TelemetryService;
+
+  beforeEach(() => {
+    mockLollipopClient = {
+      generateLCParams: vi.fn().mockResolvedValue(anLcParams),
+    } as unknown as LollipopClient;
+
+    mockTelemetryService = {
+      trackEvent: vi.fn(),
+    };
+  });
+
+  describe("successful parsing", () => {
+    it("should successfully parse valid lollipop headers with sha256 algorithm", async () => {
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      const result = await parseLollipopHeaders(
+        req,
+        mockLollipopClient,
+        mockTelemetryService,
+      );
+
+      expect(result).toEqual({
+        signature: "sig1=:mockSignature:",
+        "signature-input": aSignatureInput,
+        "x-pagopa-lollipop-assertion-ref": anLcParams.assertion_ref,
+        "x-pagopa-lollipop-assertion-type": anLcParams.assertion_type,
+        "x-pagopa-lollipop-auth-jwt": anLcParams.lc_authentication_bearer,
+        "x-pagopa-lollipop-original-method": "POST",
+        "x-pagopa-lollipop-original-url": "https://api.example.com/endpoint",
+        "x-pagopa-lollipop-public-key": anLcParams.pub_key,
+        "x-pagopa-lollipop-user-id": aFiscalCode,
+      });
+
+      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+        anAssertionRef,
+        expect.any(String), // operationId
+      );
+      expect(mockTelemetryService.trackEvent).not.toHaveBeenCalled();
+    });
+
+    it("should successfully parse headers with sha384 algorithm", async () => {
+      const sha384Thumbprint =
+        "abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzab5678cdef";
+      const sha384AssertionRef = `sha384-${sha384Thumbprint}`;
+      const sha384SignatureInput = `sig1=(); keyid="${sha384Thumbprint}"; nonce="test-nonce-123"`;
+
+      const userIdentity = createValidUserIdentity(sha384AssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(sha384SignatureInput),
+        "x-user": userHeader,
+      });
+
+      const lcParams = { ...anLcParams, assertion_ref: sha384AssertionRef };
+      vi.mocked(mockLollipopClient.generateLCParams).mockResolvedValue(
+        lcParams,
+      );
+
+      const result = await parseLollipopHeaders(
+        req,
+        mockLollipopClient,
+        mockTelemetryService,
+      );
+
+      expect(result["x-pagopa-lollipop-assertion-ref"]).toBe(
+        sha384AssertionRef,
+      );
+      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+        sha384AssertionRef,
+        "test-nonce-123",
+      );
+    });
+
+    it("should successfully parse headers with sha512 algorithm", async () => {
+      const sha512Thumbprint =
+        "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890123456789";
+      const sha512AssertionRef = `sha512-${sha512Thumbprint}`;
+      const sha512SignatureInput = `sig1=(); keyid="${sha512Thumbprint}"`;
+
+      const userIdentity = createValidUserIdentity(sha512AssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(sha512SignatureInput),
+        "x-user": userHeader,
+      });
+
+      const lcParams = { ...anLcParams, assertion_ref: sha512AssertionRef };
+      vi.mocked(mockLollipopClient.generateLCParams).mockResolvedValue(
+        lcParams,
+      );
+
+      const result = await parseLollipopHeaders(
+        req,
+        mockLollipopClient,
+        mockTelemetryService,
+      );
+
+      expect(result["x-pagopa-lollipop-assertion-ref"]).toBe(
+        sha512AssertionRef,
+      );
+    });
+
+    it("should generate a ULID as operationId when nonce is not present in signature-input", async () => {
+      const signatureInputWithoutNonce = `sig1=(); keyid="${aThumbprint}"`;
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(signatureInputWithoutNonce),
+        "x-user": userHeader,
+      });
+
+      await parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService);
+
+      // Verify that generateLCParams was called with a valid operationId (ULID format)
+      const operationId = vi.mocked(mockLollipopClient.generateLCParams).mock
+        .calls[0][1];
+      expect(operationId).toBeTruthy();
+      expect(typeof operationId).toBe("string");
+      expect(operationId.length).toBe(26); // ULID length
+    });
+  });
+
+  describe("invalid request headers", () => {
+    it("should throw MiddlewareError when lollipop request headers are missing", async () => {
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        "x-user": userHeader,
+        // Missing lollipop headers
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(
+        new MiddlewareError(
+          "Missing or invalid required lollipop headers",
+          403,
+        ),
+      );
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 403 },
+      );
+    });
+
+    it("should throw MiddlewareError when signature header is missing", async () => {
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const { signature, ...headersWithoutSignature } =
+        createValidLollipopHeaders();
+
+      const req = createMockRequest({
+        ...headersWithoutSignature,
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(MiddlewareError);
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 403 },
+      );
+    });
+
+    it("should throw MiddlewareError when signature-input header is missing", async () => {
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const {
+        "signature-input": signatureInput,
+        ...headersWithoutSignatureInput
+      } = createValidLollipopHeaders();
+
+      const req = createMockRequest({
+        ...headersWithoutSignatureInput,
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(MiddlewareError);
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 403 },
+      );
+    });
+
+    it("should throw MiddlewareError when x-pagopa-lollipop-original-method is missing", async () => {
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const {
+        "x-pagopa-lollipop-original-method": method,
+        ...headersWithoutMethod
+      } = createValidLollipopHeaders();
+
+      const req = createMockRequest({
+        ...headersWithoutMethod,
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(MiddlewareError);
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 403 },
+      );
+    });
+
+    it("should throw MiddlewareError when x-pagopa-lollipop-original-url is missing", async () => {
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const { "x-pagopa-lollipop-original-url": url, ...headersWithoutUrl } =
+        createValidLollipopHeaders();
+
+      const req = createMockRequest({
+        ...headersWithoutUrl,
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(MiddlewareError);
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 403 },
+      );
+    });
+  });
+
+  describe("invalid x-user header", () => {
+    it("should throw MiddlewareError when x-user header is missing", async () => {
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(new MiddlewareError("Missing x-user header", 401));
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 401 },
+      );
+    });
+
+    it("should throw MiddlewareError when x-user header is not valid base64", async () => {
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": "not-valid-base64!@#",
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow();
+    });
+
+    it("should throw MiddlewareError when x-user header contains invalid JSON", async () => {
+      const invalidJson = Buffer.from("not valid json").toString("base64");
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": invalidJson,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow();
+    });
+
+    it("should throw MiddlewareError when user identity is invalid", async () => {
+      const invalidUserIdentity = {
+        // Missing required fields
+        fiscal_code: aFiscalCode,
+      };
+      const userHeader = Buffer.from(
+        JSON.stringify(invalidUserIdentity),
+      ).toString("base64");
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(MiddlewareError);
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 401 },
+      );
+    });
+
+    it("should throw MiddlewareError when fiscal_code is invalid", async () => {
+      const invalidUserIdentity = {
+        ...createValidUserIdentity(anAssertionRef),
+        fiscal_code: "INVALID",
+      };
+      const userHeader = Buffer.from(
+        JSON.stringify(invalidUserIdentity),
+      ).toString("base64");
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(MiddlewareError);
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 401 },
+      );
+    });
+  });
+
+  describe("assertion_ref validation", () => {
+    it("should throw MiddlewareError when assertion_ref is missing", async () => {
+      const userIdentity = createValidUserIdentity(); // No assertion_ref
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(new MiddlewareError("AssertionRef is missing", 403));
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 403 },
+      );
+    });
+
+    it("should throw MiddlewareError when assertion_ref has invalid format", async () => {
+      // Create a user identity with an invalid assertion_ref that won't match any schema
+      const invalidUserIdentity = {
+        assertion_ref: `sha1-${aThumbprint}`, // sha1 is not supported
+        date_of_birth: "1997-10-06",
+        family_name: "Rossi",
+        fiscal_code: aFiscalCode,
+        name: "Mario",
+        spid_level: "https://www.spid.gov.it/SpidL2",
+      };
+      const userHeader = Buffer.from(JSON.stringify(invalidUserIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      // This will fail at user identity validation because sha1 format is not valid
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(MiddlewareError);
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 401 },
+      );
+    });
+
+    it("should throw MiddlewareError when assertion_ref doesn't match algo-thumbprint format", async () => {
+      const mismatchedAssertionRef = `sha256-wrongThumbprint`;
+      const userIdentity = createValidUserIdentity(mismatchedAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(new MiddlewareError("AssertionRef mismatch", 403));
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
+        { status: 403 },
+      );
+    });
+  });
+
+  describe("signature-input validation", () => {
+    it("should throw MiddlewareError when keyid is invalid in signature-input", async () => {
+      const invalidSignatureInput = `sig1=(); keyid="invalid!@#$%"`;
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(invalidSignatureInput),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(
+        new MiddlewareError("Invalid keyid in signature-input", 500),
+      );
+    });
+
+    it("should throw MiddlewareError when keyid is missing in signature-input", async () => {
+      const noKeyidSignatureInput = `sig1=(); nonce="test"`;
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(noKeyidSignatureInput),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(
+        new MiddlewareError("Invalid keyid in signature-input", 500),
+      );
+    });
+  });
+
+  describe("LollipopClient errors", () => {
+    it("should throw MiddlewareError when LollipopClient.generateLCParams fails with LollipopClientError", async () => {
+      const clientError = new LollipopClientError(
+        "Error generating LC params",
+        { detail: "Internal error", status: 500 },
+      );
+      vi.mocked(mockLollipopClient.generateLCParams).mockRejectedValue(
+        clientError,
+      );
+
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          message: "Error generating LC params",
+          status: 500,
+          body: { detail: "Internal error", status: 500 },
+        }),
+      );
+
+      expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+        TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
+        { status: 500 },
+      );
+    });
+
+    it("should throw generic Error when LollipopClient.generateLCParams fails with unexpected error", async () => {
+      const unexpectedError = new Error("Network error");
+      vi.mocked(mockLollipopClient.generateLCParams).mockRejectedValue(
+        unexpectedError,
+      );
+
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      await expect(
+        parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
+      ).rejects.toThrow("Unexpected Middleware error | Error: Network error");
+
+      expect(mockTelemetryService.trackEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle signature-input with nonce containing special characters", async () => {
+      const specialNonce = "test-nonce-with-special_chars.123";
+      const signatureInput = `sig1=(); keyid="${aThumbprint}"; nonce="${specialNonce}"`;
+
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(signatureInput),
+        "x-user": userHeader,
+      });
+
+      await parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService);
+
+      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+        anAssertionRef,
+        specialNonce,
+      );
+    });
+
+it("should handle signature-input with parameters in different order", async () => {
+      const signatureInput = `sig1=(); nonce="test"; keyid="${aThumbprint}"`;
+
+      const userIdentity = createValidUserIdentity(anAssertionRef);
+      const userHeader = Buffer.from(JSON.stringify(userIdentity)).toString(
+        "base64",
+      );
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(signatureInput),
+        "x-user": userHeader,
+      });
+
+      const result = await parseLollipopHeaders(
+        req,
+        mockLollipopClient,
+        mockTelemetryService,
+      );
+
+      expect(result).toBeDefined();
+      expect(mockLollipopClient.generateLCParams).toHaveBeenCalledWith(
+        anAssertionRef,
+        "test",
+      );
+    });
+
+    it("should handle optional user identity fields", async () => {
+      const userIdentityWithOptionals = {
+        ...createValidUserIdentity(anAssertionRef),
+        session_tracking_id: "session-123",
+        spid_email: "test@example.com",
+        spid_idp: "testIdp",
+      };
+      const userHeader = Buffer.from(
+        JSON.stringify(userIdentityWithOptionals),
+      ).toString("base64");
+
+      const req = createMockRequest({
+        ...createValidLollipopHeaders(),
+        "x-user": userHeader,
+      });
+
+      const result = await parseLollipopHeaders(
+        req,
+        mockLollipopClient,
+        mockTelemetryService,
+      );
+
+      expect(result).toBeDefined();
+      expect(result["x-pagopa-lollipop-user-id"]).toBe(aFiscalCode);
+    });
+  });
+});

--- a/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
@@ -16,15 +16,14 @@ import {
 import LollipopClient, { LollipopClientError } from "../lollipop-client.js";
 import { parseLollipopHeaders } from "../lollipop-middleware.js";
 
-// Helper to create a mock HttpRequest
 const createMockRequest = (headers: Record<string, string>): HttpRequest => {
-  const headersMap = new Map(Object.entries(headers));
-  return {
-    headers: headersMap,
-  } as unknown as HttpRequest;
+  return new HttpRequest({
+    url: "https://api.example.com/test",
+    method: "POST",
+    headers: headers,
+  });
 };
 
-// Helper to create a valid user identity
 const createValidUserIdentity = (assertionRef?: string) => ({
   assertion_ref: assertionRef,
   date_of_birth: "1997-10-06",
@@ -34,8 +33,9 @@ const createValidUserIdentity = (assertionRef?: string) => ({
   spid_level: "https://www.spid.gov.it/SpidL2",
 });
 
-// Helper to create valid lollipop request headers
-const createValidLollipopHeaders = (signatureInput?: string) => ({
+const createValidLollipopHeaders = (
+  signatureInput?: string,
+): Record<string, string> => ({
   signature: "sig1=:mockSignature:",
   "signature-input": signatureInput || aSignatureInput,
   "x-pagopa-lollipop-original-method": "POST",
@@ -433,9 +433,9 @@ describe("parseLollipopHeaders", () => {
         name: "Mario",
         spid_level: "https://www.spid.gov.it/SpidL2",
       };
-      const userHeader = Buffer.from(JSON.stringify(invalidUserIdentity)).toString(
-        "base64",
-      );
+      const userHeader = Buffer.from(
+        JSON.stringify(invalidUserIdentity),
+      ).toString("base64");
 
       const req = createMockRequest({
         ...createValidLollipopHeaders(),
@@ -599,7 +599,7 @@ describe("parseLollipopHeaders", () => {
       );
     });
 
-it("should handle signature-input with parameters in different order", async () => {
+    it("should handle signature-input with parameters in different order", async () => {
       const signatureInput = `sig1=(); nonce="test"; keyid="${aThumbprint}"`;
 
       const userIdentity = createValidUserIdentity(anAssertionRef);

--- a/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/__tests__/lollipop-middleware.test.ts
@@ -206,7 +206,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 403 },
+      expect.objectContaining({ status: 403 }),
     );
   });
 
@@ -232,7 +232,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 403 },
+      expect.objectContaining({ status: 403 }),
     );
   });
 
@@ -258,7 +258,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 403 },
+      expect.objectContaining({ status: 403 }),
     );
   });
 
@@ -283,7 +283,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 403 },
+      expect.objectContaining({ status: 403 }),
     );
   });
 
@@ -308,7 +308,7 @@ describe("parseLollipopHeaders invalid request headers", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 403 },
+      expect.objectContaining({ status: 403 }),
     );
   });
 });
@@ -338,7 +338,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 401 },
+      expect.objectContaining({ status: 401 }),
     );
   });
 
@@ -386,7 +386,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 401 },
+      expect.objectContaining({ status: 401 }),
     );
   });
 
@@ -410,7 +410,7 @@ describe("parseLollipopHeaders invalid x-user header", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 401 },
+      expect.objectContaining({ status: 401 }),
     );
   });
 });
@@ -445,7 +445,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 403 },
+      expect.objectContaining({ status: 403 }),
     );
   });
 
@@ -474,7 +474,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 401 },
+      expect.objectContaining({ status: 401 }),
     );
   });
 
@@ -496,7 +496,7 @@ describe("parseLollipopHeaders assertion_ref validation", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
-      { status: 403 },
+      expect.objectContaining({ status: 403 }),
     );
   });
 });
@@ -597,7 +597,7 @@ describe("LollipopClient errors", () => {
 
     expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
-      { status: 500 },
+      expect.objectContaining({ status: 500 }),
     );
   });
 
@@ -621,7 +621,9 @@ describe("LollipopClient errors", () => {
       parseLollipopHeaders(req, mockLollipopClient, mockTelemetryService),
     ).rejects.toThrow("Unexpected Middleware error | Error: Network error");
 
-    expect(mockTelemetryService.trackEvent).not.toHaveBeenCalled();
+    expect(mockTelemetryService.trackEvent).toHaveBeenCalledWith(
+      TelemetryEventName.LOLLIPOP_MIDDLEWARE_GENERIC_SERVER_ERROR,
+    );
   });
 });
 

--- a/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
@@ -86,8 +86,8 @@ export const parseLollipopHeaders = async (
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
         body: z.treeifyError(parsedRequestHeaders.error),
-        status: 403,
         requestPath: new URL(req.url).pathname,
+        status: 403,
       },
     );
     throw new MiddlewareError(
@@ -104,8 +104,8 @@ export const parseLollipopHeaders = async (
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
         body: "Missing x-user header",
-        status: 401,
         requestPath: new URL(req.url).pathname,
+        status: 401,
       },
     );
     throw new MiddlewareError("Missing x-user header", 401);
@@ -120,8 +120,8 @@ export const parseLollipopHeaders = async (
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
         body: JSON.stringify(z.treeifyError(parsedUser.error)),
-        status: 401,
         requestPath: new URL(req.url).pathname,
+        status: 401,
       },
     );
     throw new MiddlewareError(`Invalid x-user header ${parsedUser.error}`, 401);
@@ -139,8 +139,8 @@ export const parseLollipopHeaders = async (
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
         body: "Missing AssertionRef in user identity",
-        status: 403,
         requestPath: new URL(req.url).pathname,
+        status: 403,
       },
     );
     throw new MiddlewareError("AssertionRef is missing", 403);
@@ -152,8 +152,8 @@ export const parseLollipopHeaders = async (
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
         body: "AssertionRef mismatch",
-        status: 403,
         requestPath: new URL(req.url).pathname,
+        status: 403,
       },
     );
     throw new MiddlewareError("AssertionRef mismatch", 403);
@@ -179,8 +179,8 @@ export const parseLollipopHeaders = async (
         TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
         {
           body: JSON.stringify(err.body),
-          status: 500,
           requestPath: new URL(req.url).pathname,
+          status: 500,
         },
       );
       throw new MiddlewareError(err.message, 500, err.body);

--- a/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
@@ -1,3 +1,4 @@
+import { TelemetryEventName, TelemetryService } from "@/domain/telemetry.js";
 import { HttpRequest } from "@azure/functions";
 import { ulid } from "ulid";
 
@@ -20,7 +21,6 @@ import { lollipopRequestHeadersSchema } from "./definitions/request-headers.js";
 import { LollipopSignatureInput } from "./definitions/signature-input.js";
 import { Thumbprint, thumbprintSchema } from "./definitions/thumbprint.js";
 import LollipopClient, { LollipopClientError } from "./lollipop-client.js";
-import { TelemetryEventName, TelemetryService } from "@/domain/telemetry.js";
 
 const algoSchemaMap: {
   algo: JwkPubKeyHashAlgorithm;

--- a/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
@@ -1,6 +1,7 @@
 import { TelemetryEventName, TelemetryService } from "@/domain/telemetry.js";
 import { HttpRequest } from "@azure/functions";
 import { ulid } from "ulid";
+import z from "zod";
 
 import { userIdentitySchema } from "../auth/user-identity.js";
 import { Middleware, MiddlewareError } from "../middleware.js";
@@ -21,7 +22,6 @@ import { lollipopRequestHeadersSchema } from "./definitions/request-headers.js";
 import { LollipopSignatureInput } from "./definitions/signature-input.js";
 import { Thumbprint, thumbprintSchema } from "./definitions/thumbprint.js";
 import LollipopClient, { LollipopClientError } from "./lollipop-client.js";
-import z from "zod";
 
 const algoSchemaMap: {
   algo: JwkPubKeyHashAlgorithm;
@@ -85,8 +85,8 @@ export const parseLollipopHeaders = async (
     telemetryService.trackEvent(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
-        status: 403,
         body: z.treeifyError(parsedRequestHeaders.error),
+        status: 403,
       },
     );
     throw new MiddlewareError(
@@ -102,8 +102,8 @@ export const parseLollipopHeaders = async (
     telemetryService.trackEvent(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
-        status: 401,
         body: "Missing x-user header",
+        status: 401,
       },
     );
     throw new MiddlewareError("Missing x-user header", 401);
@@ -117,8 +117,8 @@ export const parseLollipopHeaders = async (
     telemetryService.trackEvent(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
-        status: 401,
         body: JSON.stringify(z.treeifyError(parsedUser.error)),
+        status: 401,
       },
     );
     throw new MiddlewareError(`Invalid x-user header ${parsedUser.error}`, 401);
@@ -135,8 +135,8 @@ export const parseLollipopHeaders = async (
     telemetryService.trackEvent(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
-        status: 403,
         body: "Missing AssertionRef in user identity",
+        status: 403,
       },
     );
     throw new MiddlewareError("AssertionRef is missing", 403);
@@ -147,8 +147,8 @@ export const parseLollipopHeaders = async (
     telemetryService.trackEvent(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR,
       {
-        status: 403,
         body: "AssertionRef mismatch",
+        status: 403,
       },
     );
     throw new MiddlewareError("AssertionRef mismatch", 403);
@@ -173,8 +173,8 @@ export const parseLollipopHeaders = async (
       telemetryService.trackEvent(
         TelemetryEventName.LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR,
         {
-          status: 500,
           body: JSON.stringify(err.body),
+          status: 500,
         },
       );
       throw new MiddlewareError(err.message, 500, err.body);

--- a/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
+++ b/packages/io-messages-common/src/adapters/lollipop/lollipop-middleware.ts
@@ -87,6 +87,7 @@ export const parseLollipopHeaders = async (
       {
         body: z.treeifyError(parsedRequestHeaders.error),
         status: 403,
+        requestPath: new URL(req.url).pathname,
       },
     );
     throw new MiddlewareError(
@@ -104,6 +105,7 @@ export const parseLollipopHeaders = async (
       {
         body: "Missing x-user header",
         status: 401,
+        requestPath: new URL(req.url).pathname,
       },
     );
     throw new MiddlewareError("Missing x-user header", 401);
@@ -119,6 +121,7 @@ export const parseLollipopHeaders = async (
       {
         body: JSON.stringify(z.treeifyError(parsedUser.error)),
         status: 401,
+        requestPath: new URL(req.url).pathname,
       },
     );
     throw new MiddlewareError(`Invalid x-user header ${parsedUser.error}`, 401);
@@ -137,6 +140,7 @@ export const parseLollipopHeaders = async (
       {
         body: "Missing AssertionRef in user identity",
         status: 403,
+        requestPath: new URL(req.url).pathname,
       },
     );
     throw new MiddlewareError("AssertionRef is missing", 403);
@@ -149,6 +153,7 @@ export const parseLollipopHeaders = async (
       {
         body: "AssertionRef mismatch",
         status: 403,
+        requestPath: new URL(req.url).pathname,
       },
     );
     throw new MiddlewareError("AssertionRef mismatch", 403);
@@ -175,6 +180,7 @@ export const parseLollipopHeaders = async (
         {
           body: JSON.stringify(err.body),
           status: 500,
+          requestPath: new URL(req.url).pathname,
         },
       );
       throw new MiddlewareError(err.message, 500, err.body);
@@ -182,6 +188,9 @@ export const parseLollipopHeaders = async (
 
     telemetryService.trackEvent(
       TelemetryEventName.LOLLIPOP_MIDDLEWARE_GENERIC_SERVER_ERROR,
+      {
+        requestPath: new URL(req.url).pathname,
+      },
     );
     throw new Error(`Unexpected Middleware error | ${err}`);
   }

--- a/packages/io-messages-common/src/domain/telemetry.ts
+++ b/packages/io-messages-common/src/domain/telemetry.ts
@@ -3,7 +3,7 @@ export interface TelemetryService {
 }
 
 export enum TelemetryEventName {
+  LOLLIPOP_MIDDLEWARE_GENERIC_SERVER_ERROR = "io.com.lollipop.middleware.generic_server_error",
   LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR = "io.com.lollipop.middleware.get_lc_params_error",
   LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR = "io.com.lollipop.middleware.malformed_headers_error",
-  LOLLIPOP_MIDDLEWARE_GENERIC_SERVER_ERROR = "io.com.lollipop.middleware.generic_server_error",
 }

--- a/packages/io-messages-common/src/domain/telemetry.ts
+++ b/packages/io-messages-common/src/domain/telemetry.ts
@@ -5,4 +5,5 @@ export interface TelemetryService {
 export enum TelemetryEventName {
   LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR = "io.com.lollipop.middleware.get_lc_params_error",
   LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR = "io.com.lollipop.middleware.malformed_headers_error",
+  LOLLIPOP_MIDDLEWARE_GENERIC_SERVER_ERROR = "io.com.lollipop.middleware.generic_server_error",
 }

--- a/packages/io-messages-common/src/domain/telemetry.ts
+++ b/packages/io-messages-common/src/domain/telemetry.ts
@@ -1,0 +1,8 @@
+export interface TelemetryService {
+  trackEvent(name: string, properties?: object): void;
+}
+
+export enum TelemetryEventName {
+  LOLLIPOP_MIDDLEWARE_GET_LC_PARAMS_ERROR = "io.com.lollipop.middleware.get_lc_params_error",
+  LOLLIPOP_MIDDLEWARE_MALFORMED_HEADERS_ERROR = "io.com.lollipop.middleware.malformed_headers_error",
+}

--- a/packages/io-messages-common/vitest.config.js
+++ b/packages/io-messages-common/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import * as path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Closes: IOCOM-2894

lollipop-middleware package now use the telemetry client.

We can now track if a request have specific missing headers or if the lollipop service, that we call for the lc_params generation, returns an unexpected response.