### PR TITLE
Update ExtensionBundle v3 -> v4 on services-func

### DIFF
--- a/.changeset/petite-hands-pump.md
+++ b/.changeset/petite-hands-pump.md
@@ -1,0 +1,5 @@
+---
+"services-func": patch
+---
+
+Upgrade ExtensionBundle v3 -> v4

--- a/apps/services-func/host.json
+++ b/apps/services-func/host.json
@@ -18,6 +18,6 @@
   },
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.3.0, 4.0.0)"
+    "version": "[4.*, 5.0.0)"
   }
 }


### PR DESCRIPTION
Bindings used on services-func, no breaking changes found.

Closes IOCOM-2982.