### PR TITLE
Update ExtensionBundle v3 -> v4 on citizen-func

### DIFF
--- a/.changeset/clear-pumas-buy.md
+++ b/.changeset/clear-pumas-buy.md
@@ -1,0 +1,5 @@
+---
+"citizen-func": patch
+---
+
+Upgrade ExtensionBundle v3 -> v4

--- a/apps/citizen-func/host.json
+++ b/apps/citizen-func/host.json
@@ -14,10 +14,10 @@
         "includedTypes": "PageView;Trace;Dependency;Request",
         "excludedTypes": "Exception;Event;CustomEvent"
       }
-    },
-    "extensionBundle": {
-      "id": "Microsoft.Azure.Functions.ExtensionBundle",
-      "version": "[3.3.0, 4.0.0)"
     }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
   }
 }


### PR DESCRIPTION
citizen-func uses only Http bindings (in and out), no breaking changes found.

Closes [IOCOM-2981](https://pagopa.atlassian.net/browse/IOCOM-2981)

[IOCOM-2981]: https://pagopa.atlassian.net/browse/IOCOM-2981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ