### PR TITLE
Update send-func node version

### DIFF
--- a/infra/resources/_modules/web_apps/send_func.tf
+++ b/infra/resources/_modules/web_apps/send_func.tf
@@ -26,6 +26,8 @@ module "send_func" {
     instance_number = "01"
   })
 
+  node_version = 22
+
   application_insights_connection_string   = var.application_insights.connection_string
   application_insights_sampling_percentage = var.application_insights.sampling_percentage
 


### PR DESCRIPTION
Update node version from node v20 to node v22
Send-func locally tested using node 22 and running the send-func Bruno collection using the Mockoon mocks.

Closes: IOCOM-2980