### PR TITLE
Update etl-func node version

### DIFF
--- a/infra/resources/_modules/web_apps/etl_func.tf
+++ b/infra/resources/_modules/web_apps/etl_func.tf
@@ -52,9 +52,10 @@ module "etl_func" {
 
   app_settings = local.etl_func.app_settings
 
-  sticky_app_setting_names = ["NODE_ENV", "AzureWebJobs.IngestMessageStatus.Disabled"]
+  sticky_app_setting_names = ["NODE_ENV", "AzureWebJobs.IngestMessageStatus.Disabled", "AzureWebJobs.IngestMessages.Disabled"]
   slot_app_settings = merge(local.etl_func.app_settings, {
     "AzureWebJobs.IngestMessageStatus.Disabled" = "1"
+    "AzureWebJobs.IngestMessages.Disabled"      = "1"
   })
 
   virtual_network = var.virtual_network

--- a/infra/resources/_modules/web_apps/etl_func.tf
+++ b/infra/resources/_modules/web_apps/etl_func.tf
@@ -38,6 +38,8 @@ module "etl_func" {
     instance_number = "01"
   })
 
+  node_version = 22
+
   application_insights_connection_string   = var.application_insights.connection_string
   application_insights_sampling_percentage = var.application_insights.sampling_percentage
 

--- a/infra/resources/prod/tfmodules.lock.json
+++ b/infra/resources/prod/tfmodules.lock.json
@@ -108,10 +108,10 @@
     "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/1.0.1"
   },
   "web_apps.citizen_func_new": {
-    "hash": "0ebbe863c7b48075ef6a3a79465fd2905aca43e043065a4e8d07dd90d28499dd",
-    "version": "4.2.1",
+    "hash": "0896695540ef03c38ad57186a72589ffd6bca2e658bebfc05040bd44bd26897f",
+    "version": "4.3.0",
     "name": "azure_function_app",
-    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.2.1"
+    "source": "https://registry.terraform.io/modules/pagopa-dx/azure-function-app/azurerm/4.3.0"
   },
   "web_apps.citizen_func_autoscaler_new": {
     "hash": "0ce217941a45b1d47e10fd2c908ee084a98370b5ca797d57e314afc2fc7a07a3",


### PR DESCRIPTION
Upgrade etl-func node version runtime from 20 to 22 LTS.

Successfully tested the etl-func triggers locally under the node 22 LTS  runtime.

Closes: IOCOM-2978