### PR TITLE
Update ops-func node version 

### DIFF
--- a/apps/ops-func/local.settings.json.example
+++ b/apps/ops-func/local.settings.json.example
@@ -6,6 +6,7 @@
     "COSMOS_URI":"https://io-d-itn-common-cosno-01.documents.azure.com:443/",
     "COSMOS_DATABASE_NAME": "io-messages",
     "COMMON_STORAGE_ACCOUNT_URL":"https://testgiovannist.blob.core.windows.net/",
-    "STORAGE_ACCOUNT__serviceUri": "https://testgiovannist.blob.core.windows.net/"
+    "STORAGE_ACCOUNT__serviceUri": "https://testgiovannist.blob.core.windows.net/",
+    "STORAGE_ACCOUNT__queueServiceUri": "https://testgiovannist.queue.core.windows.net/"
   }
 }

--- a/infra/resources/_modules/web_apps/ops_func.tf
+++ b/infra/resources/_modules/web_apps/ops_func.tf
@@ -23,6 +23,8 @@ module "ops_func" {
     instance_number = "01"
   })
 
+  node_version = 22
+
   application_insights_connection_string   = var.application_insights.connection_string
   application_insights_sampling_percentage = var.application_insights.sampling_percentage
 


### PR DESCRIPTION
Successfully locally tested:
1. creating messages using the services-func
2. adding a csv file containing the data of the messages previously created into the blob storage for triggering the ops function

Closes: IOCOM-2991