### PR TITLE
Add startFromBeginning in UpdateInstallationDispatcher

### DIFF
--- a/.changeset/puny-experts-tie.md
+++ b/.changeset/puny-experts-tie.md
@@ -1,0 +1,5 @@
+---
+"pushnotif-func": patch
+---
+
+Add startFromBeginning in UpdateInstallationDispatcher

--- a/apps/pushnotif-func/src/main.ts
+++ b/apps/pushnotif-func/src/main.ts
@@ -271,6 +271,7 @@ const main = (config: Config) => {
       },
       strategy: "exponentialBackoff",
     },
+    startFromBeginning: true,
   });
 
   app.storageQueue("UpdateInstallation", {


### PR DESCRIPTION
Without this property the dispatcher will not start from the beginning when the lease prefix is updated.