### PR TITLE
Update error types for the notification repository

### DIFF
--- a/.changeset/thick-groups-cough.md
+++ b/.changeset/thick-groups-cough.md
@@ -1,0 +1,10 @@
+---
+"pushnotif-func": patch
+---
+
+Update error types for the notification repository.
+
+- Add `ErrorTooManyRequests`
+- Make updateInstallation return `ErrorTooManyRequests`
+- Make updateInstallation return `ErrorInternal`
+- Remove `ZodError` as return type of updateInstallation (never happens)

--- a/apps/pushnotif-func/src/adapters/functions/__tests__/update-installation.test.ts
+++ b/apps/pushnotif-func/src/adapters/functions/__tests__/update-installation.test.ts
@@ -1,7 +1,11 @@
 import { InvocationContext } from "@azure/functions";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
-import { ErrorNotFound } from "../../../domain/error";
+import {
+  ErrorInternal,
+  ErrorNotFound,
+  ErrorTooManyRequests,
+} from "../../../domain/error";
 import { InstallationRepository } from "../../../domain/push-service";
 import { TelemetryService } from "../../../domain/telemetry";
 import getUpdateInstallationHandler from "../update-installation";
@@ -111,15 +115,31 @@ describe("getUpdateInstallationHandler", () => {
     ).toHaveBeenCalledOnce();
   });
 
-  test("should throw when updateInstallation returns a generic error", async () => {
+  test("should throw when updateInstallation returns a ErrorInternal", async () => {
     vi.mocked(
       installationRepositoryMock.updateInstallation,
-    ).mockResolvedValueOnce(new Error("Update failed"));
+    ).mockResolvedValueOnce(new ErrorInternal("Update failed"));
 
     const message = { installationId: aValidInstallationId, platform: "Apns" };
 
     await expect(handler(message, invocationContext)).rejects.toThrow(
       "Update failed",
+    );
+
+    expect(
+      installationRepositoryMock.updateInstallation,
+    ).toHaveBeenCalledOnce();
+  });
+
+  test("should throw when updateInstallation returns a ErrorTooManyRequests", async () => {
+    vi.mocked(
+      installationRepositoryMock.updateInstallation,
+    ).mockResolvedValueOnce(new ErrorTooManyRequests("Too many requests"));
+
+    const message = { installationId: aValidInstallationId, platform: "Apns" };
+
+    await expect(handler(message, invocationContext)).rejects.toThrow(
+      "Too many requests",
     );
 
     expect(

--- a/apps/pushnotif-func/src/adapters/functions/update-installation.ts
+++ b/apps/pushnotif-func/src/adapters/functions/update-installation.ts
@@ -1,7 +1,11 @@
 import { StorageQueueHandler } from "@azure/functions";
 import z from "zod";
 
-import { ErrorNotFound } from "../../domain/error";
+import {
+  ErrorInternal,
+  ErrorNotFound,
+  ErrorTooManyRequests,
+} from "../../domain/error";
 import { supportedPlatformSchema } from "../../domain/installation";
 import { JsonPatch } from "../../domain/json-patch";
 import { InstallationRepository } from "../../domain/push-service";
@@ -73,7 +77,11 @@ const getUpdateInstallationHandler =
       return;
     }
 
-    if (errorOrUpdatedInstallation instanceof Error) {
+    if (
+      errorOrUpdatedInstallation instanceof ErrorInternal ||
+      errorOrUpdatedInstallation instanceof ErrorTooManyRequests
+    ) {
+      // In those cases we want to retry the operation.
       throw errorOrUpdatedInstallation;
     }
   };

--- a/apps/pushnotif-func/src/adapters/notification-hub/installation.ts
+++ b/apps/pushnotif-func/src/adapters/notification-hub/installation.ts
@@ -1,8 +1,11 @@
 import { NotificationHubsClient } from "@azure/notification-hubs";
 import { RestError } from "@azure/storage-queue";
-import { z } from "zod";
 
-import { ErrorNotFound } from "../../domain/error";
+import {
+  ErrorInternal,
+  ErrorNotFound,
+  ErrorTooManyRequests,
+} from "../../domain/error";
 import { JsonPatch } from "../../domain/json-patch";
 import { InstallationRepository } from "../../domain/push-service";
 
@@ -41,10 +44,7 @@ export class NotificationHubInstallationAdapter
     }
   }
 
-  async updateInstallation(
-    id: string,
-    patches: JsonPatch[],
-  ): Promise<Error | string> {
+  async updateInstallation(id: string, patches: JsonPatch[]) {
     const nhPartition = this.getPartition(id);
 
     try {
@@ -57,19 +57,17 @@ export class NotificationHubInstallationAdapter
           case 404:
             return new ErrorNotFound(`Installation not found`, err);
           case 429:
-            return new Error(`Too many request to notification hub`);
+            return new ErrorTooManyRequests(
+              `Too many request to notification hub`,
+            );
           default:
-            return new Error(`Generic error from notification hub ${err}`);
+            return new ErrorInternal(
+              `Generic error from notification hub: ${err.message}`,
+            );
         }
       }
 
-      if (err instanceof z.ZodError) {
-        return new Error(
-          `Error parsing the installation from notification hub ${err}`,
-        );
-      }
-
-      return new Error(`Error from notification hub: ${err}`);
+      return new ErrorInternal(`Error from notification hub: ${err}`);
     }
   }
 }

--- a/apps/pushnotif-func/src/domain/error.ts
+++ b/apps/pushnotif-func/src/domain/error.ts
@@ -1,4 +1,15 @@
 // TODO: move this file to io-messages-common
+
+export class ErrorValidation extends Error {
+  cause: unknown;
+  code = "400";
+
+  constructor(name: string, cause: unknown = "") {
+    super(name);
+    this.cause = cause;
+  }
+}
+
 export class ErrorNotFound extends Error {
   cause: unknown;
   code = "404";
@@ -9,9 +20,9 @@ export class ErrorNotFound extends Error {
   }
 }
 
-export class ErrorInternal extends Error {
+export class ErrorTooManyRequests extends Error {
   cause: unknown;
-  code = "500";
+  code = "429";
 
   constructor(name: string, cause: unknown = "") {
     super(name);
@@ -19,9 +30,9 @@ export class ErrorInternal extends Error {
   }
 }
 
-export class ErrorValidation extends Error {
+export class ErrorInternal extends Error {
   cause: unknown;
-  code = "400";
+  code = "500";
 
   constructor(name: string, cause: unknown = "") {
     super(name);

--- a/apps/pushnotif-func/src/domain/push-service.ts
+++ b/apps/pushnotif-func/src/domain/push-service.ts
@@ -1,5 +1,13 @@
+import { ErrorInternal, ErrorNotFound, ErrorTooManyRequests } from "./error";
 import { JsonPatch } from "./json-patch";
 
 export interface InstallationRepository {
-  updateInstallation(id: string, patches: JsonPatch[]): Promise<Error | string>;
+  /**
+   * updateInstallation perform an update operation on the installation
+   * identified by the `id` using the provided patches.
+   * */
+  updateInstallation(
+    id: string,
+    patches: JsonPatch[],
+  ): Promise<ErrorInternal | ErrorNotFound | ErrorTooManyRequests | string>;
 }


### PR DESCRIPTION
- Add `ErrorTooManyRequests`
- Make updateInstallation return `ErrorTooManyRequests`
- Make updateInstallation return `ErrorInternal`
- Remove `ZodError` as return type of updateInstallation (never happens)