### PR TITLE
Add poison alerts

### DIFF
--- a/.github/workflows/infra-review.yaml
+++ b/.github/workflows/infra-review.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   infra_review:
-    uses: pagopa/dx/.github/workflows/infra_plan.yaml@7e6e88cf29984e3a54589e1ed51a335e016b3f47
+    uses: pagopa/dx/.github/workflows/infra_plan.yaml@main
     name: PR Prod WestEurope
     secrets: inherit
     with:

--- a/apps/pushnotif-func/local.settings.json.example
+++ b/apps/pushnotif-func/local.settings.json.example
@@ -28,7 +28,6 @@
     "NH4_ENDPOINT": "NotificationHubPartitionConnectionString",
     "NH4_NAME": "io-p-itn-com-nh-sandbox",
     "NH4_PARTITION_REGEX":"^[ \"c-f]",
-    "NOTIFY_MESSAGE_QUEUE_NAME": "notify-queue-name",
     "NODE_TLS_REJECT_UNAUTHORIZED": "0",
     "AZURE_ENABLE_STRICT_SSL": "false",
     "MESSAGE_CONTAINER_NAME": "message-content",

--- a/infra/resources/_modules/monitoring/README.md
+++ b/infra/resources/_modules/monitoring/README.md
@@ -32,6 +32,13 @@ No modules.
 | [azurerm_monitor_scheduled_query_rules_alert_v2.massive_job_process_progress_create_failed_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.massive_job_process_queue_message_invalid_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 | [azurerm_monitor_scheduled_query_rules_alert_v2.massive_job_start_schedule_batch_failed_alert](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.pushnotif_notify_messages_poison_queue_not_empty](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.pushnotif_push_notifications_poison_queue_not_empty](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.pushnotif_update_installations_dispatch_poison_queue_not_empty](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.services_message_created_poison_queue_not_empty](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.services_message_processed_poison_queue_not_empty](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.services_notification_created_email_poison_queue_not_empty](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
+| [azurerm_monitor_scheduled_query_rules_alert_v2.services_notification_created_webhook_poison_queue_not_empty](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_scheduled_query_rules_alert_v2) | resource |
 
 ## Inputs
 

--- a/infra/resources/_modules/monitoring/monitoring.tf
+++ b/infra/resources/_modules/monitoring/monitoring.tf
@@ -434,3 +434,262 @@ resource "azurerm_monitor_scheduled_query_rules_alert_v2" "massive_job_process_m
     ]
   }
 }
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "pushnotif_push_notifications_poison_queue_not_empty" {
+  name                = format("[%s-%s] PushNotif - push-notifications-poison not empty", var.project, var.domain)
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [var.com_st_id]
+  description             = "[IO-COM] One or more messages have been moved to the `push-notifications-poison` queue after exhausting all retries. The HandleNHNotificationCall function failed to process them: investigate the function logs and drain the poison queue."
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  severity             = 1
+  evaluation_frequency = "PT10M"
+  window_duration      = "PT10M"
+
+  criteria {
+    query                   = <<-QUERY
+       StorageQueueLogs
+         | where OperationName has "PutMessage"
+         | where Uri has "push-notifications-poison"
+       QUERY
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.io_com_error.id
+    ]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "pushnotif_notify_messages_poison_queue_not_empty" {
+  name                = format("[%s-%s] PushNotif - notify-messages-poison not empty", var.project, var.domain)
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [var.com_st_id]
+  description             = "[IO-COM] One or more messages have been moved to the `notify-messages-poison` queue after exhausting all retries. The HandleNHNotifyMessageCallActivityQueue function failed to process them: investigate the function logs and drain the poison queue."
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  severity             = 1
+  evaluation_frequency = "PT10M"
+  window_duration      = "PT10M"
+
+  criteria {
+    query                   = <<-QUERY
+       StorageQueueLogs
+         | where OperationName has "PutMessage"
+         | where Uri has "notify-messages-poison"
+       QUERY
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.io_com_error.id
+    ]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "pushnotif_update_installations_dispatch_poison_queue_not_empty" {
+  name                = format("[%s-%s] PushNotif - update-installations-dispatch-poison not empty", var.project, var.domain)
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [var.com_st_id]
+  description             = "[IO-COM] One or more messages have been moved to the `update-installations-dispatch-poison` queue after exhausting all retries. The UpdateInstallation function failed to process them: investigate the function logs and drain the poison queue."
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  severity             = 1
+  evaluation_frequency = "PT10M"
+  window_duration      = "PT10M"
+
+  criteria {
+    query                   = <<-QUERY
+       StorageQueueLogs
+         | where OperationName has "PutMessage"
+         | where Uri has "update-installations-dispatch-poison"
+       QUERY
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.io_com_error.id
+    ]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "services_message_created_poison_queue_not_empty" {
+  name                = format("[%s-%s] Services - message-created-poison not empty", var.project, var.domain)
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [var.com_st_id]
+  description             = "[IO-COM] One or more messages have been moved to the `message-created-poison` queue after exhausting all retries. The ProcessMessage function failed to process them: investigate the function logs and drain the poison queue."
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  severity             = 1
+  evaluation_frequency = "PT10M"
+  window_duration      = "PT10M"
+
+  criteria {
+    query                   = <<-QUERY
+       StorageQueueLogs
+         | where OperationName has "PutMessage"
+         | where Uri has "message-created-poison"
+       QUERY
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.io_com_error.id
+    ]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "services_message_processed_poison_queue_not_empty" {
+  name                = format("[%s-%s] Services - message-processed-poison not empty", var.project, var.domain)
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [var.com_st_id]
+  description             = "[IO-COM] One or more messages have been moved to the `message-processed-poison` queue after exhausting all retries. The CreateNotification function failed to process them: investigate the function logs and drain the poison queue."
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  severity             = 1
+  evaluation_frequency = "PT10M"
+  window_duration      = "PT10M"
+
+  criteria {
+    query                   = <<-QUERY
+       StorageQueueLogs
+         | where OperationName has "PutMessage"
+         | where Uri has "message-processed-poison"
+       QUERY
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.io_com_error.id
+    ]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "services_notification_created_email_poison_queue_not_empty" {
+  name                = format("[%s-%s] Services - notification-created-email-poison not empty", var.project, var.domain)
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [var.com_st_id]
+  description             = "[IO-COM] One or more messages have been moved to the `notification-created-email-poison` queue after exhausting all retries. The EmailNotification function failed to process them: investigate the function logs and drain the poison queue."
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  severity             = 1
+  evaluation_frequency = "PT10M"
+  window_duration      = "PT10M"
+
+  criteria {
+    query                   = <<-QUERY
+       StorageQueueLogs
+         | where OperationName has "PutMessage"
+         | where Uri has "notification-created-email-poison"
+       QUERY
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.io_com_error.id
+    ]
+  }
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "services_notification_created_webhook_poison_queue_not_empty" {
+  name                = format("[%s-%s] Services - notification-created-webhook-poison not empty", var.project, var.domain)
+  resource_group_name = var.resource_group_name
+  location            = var.location
+
+  scopes                  = [var.com_st_id]
+  description             = "[IO-COM] One or more messages have been moved to the `notification-created-webhook-poison` queue after exhausting all retries. The WebhookNotification function failed to process them: investigate the function logs and drain the poison queue."
+  enabled                 = true
+  auto_mitigation_enabled = false
+
+  severity             = 1
+  evaluation_frequency = "PT10M"
+  window_duration      = "PT10M"
+
+  criteria {
+    query                   = <<-QUERY
+       StorageQueueLogs
+         | where OperationName has "PutMessage"
+         | where Uri has "notification-created-webhook-poison"
+       QUERY
+    time_aggregation_method = "Count"
+    threshold               = 1
+    operator                = "GreaterThanOrEqual"
+
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  action {
+    action_groups = [
+      azurerm_monitor_action_group.io_com_error.id
+    ]
+  }
+}

--- a/infra/resources/_modules/storage_accounts/README.md
+++ b/infra/resources/_modules/storage_accounts/README.md
@@ -47,8 +47,8 @@ No requirements.
 | [azurerm_storage_queue.notification_created_poison](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.process_massive_job](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.process_massive_job_poison](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
-| [azurerm_storage_queue.push_notif_notifymessage](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
-| [azurerm_storage_queue.push_notif_notifymessage_poison](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_storage_queue.push_notif_notify_messages](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_storage_queue.push_notif_notify_messages_poison](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.push_notifications](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.push_notifications_poison](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 | [azurerm_storage_queue.update_installations_dispatch](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |

--- a/infra/resources/_modules/storage_accounts/storage_account_io_com.tf
+++ b/infra/resources/_modules/storage_accounts/storage_account_io_com.tf
@@ -60,18 +60,18 @@ resource "azurerm_storage_queue" "push_notifications" {
   storage_account_name = module.com_st.name
 }
 
-resource "azurerm_storage_queue" "push_notif_notifymessage" {
-  name                 = "notify-message"
+resource "azurerm_storage_queue" "push_notif_notify_messages" {
+  name                 = "notify-messages"
+  storage_account_name = module.com_st.name
+}
+
+resource "azurerm_storage_queue" "push_notif_notify_messages_poison" {
+  name                 = "notify-messages-poison"
   storage_account_name = module.com_st.name
 }
 
 resource "azurerm_storage_queue" "message_paymentupdater_failures" {
   name                 = "message-paymentupdater-failures"
-  storage_account_name = module.com_st.name
-}
-
-resource "azurerm_storage_queue" "push_notif_notifymessage_poison" {
-  name                 = "${azurerm_storage_queue.push_notif_notifymessage.name}-poison"
   storage_account_name = module.com_st.name
 }
 

--- a/infra/resources/_modules/web_apps/pushnotif-func.tf
+++ b/infra/resources/_modules/web_apps/pushnotif-func.tf
@@ -45,8 +45,6 @@ locals {
       NOTIFICATIONS_QUEUE_NAME                = "push-notifications"
       NOTIFICATIONS_STORAGE_CONNECTION_STRING = var.com_st_connectiostring
 
-      NOTIFY_MESSAGE_QUEUE_NAME = "notify-message"
-
       // activity default retry attempts
       RETRY_ATTEMPT_NUMBER = 10
 

--- a/infra/resources/prod/import.tf
+++ b/infra/resources/prod/import.tf
@@ -1,0 +1,4 @@
+import {
+  to = module.storage_api_weu.azurerm_storage_queue.push_notif_notify_messages
+  id = "https://iopitncomst01.queue.core.windows.net/notify-messages"
+}


### PR DESCRIPTION
- Add alerts for non empty poison queues
- Remove unused queues `notify-message` and `notify-message-poison`
- Import `notify-messages` queue in terraform configuration
- Create new `notify-messages-poison` queue
- Remove unused env var `NOTIFU_MESSAGE_QUEUE_NAME`

Closes IOCOM-3116