### PR TITLE
Remove unused variable from Azure Bootstrap module

### DIFF
--- a/infra/bootstrapper/prod/main.tf
+++ b/infra/bootstrapper/prod/main.tf
@@ -117,8 +117,8 @@ module "repo" {
   }
 
   github_private_runner = {
-    container_app_environment_id       = data.azurerm_container_app_environment.runner.id
-    container_app_environment_location = data.azurerm_container_app_environment.runner.location
+    container_app_environment_id = data.azurerm_container_app_environment.runner.id
+    use_github_app               = true
     key_vault = {
       name                = local.runner.secret.kv_name
       resource_group_name = local.runner.secret.kv_resource_group_name


### PR DESCRIPTION
This pull request makes a targeted configuration update to the `repo` module in the production bootstrapper. The change enables the use of GitHub App authentication for the GitHub private runner.

- Runner authentication:
  * Set `use_github_app` to `true` in the `github_private_runner` configuration, enabling GitHub App authentication for the runner.