### PR TITLE
Remove Message Content Connection String from Terraform configuration

### DIFF
--- a/.changeset/fine-toys-beg.md
+++ b/.changeset/fine-toys-beg.md
@@ -1,5 +1,0 @@
----
-"citizen-func": patch
----
-
-Removing message content connection string from terraform configuration

--- a/.changeset/fine-toys-beg.md
+++ b/.changeset/fine-toys-beg.md
@@ -1,0 +1,5 @@
+---
+"citizen-func": patch
+---
+
+Removing message content connection string from terraform configuration

--- a/infra/resources/_modules/web_apps/citizen-func.tf
+++ b/infra/resources/_modules/web_apps/citizen-func.tf
@@ -12,9 +12,8 @@ locals {
       REMOTE_CONTENT_COSMOSDB_URI  = var.io_com_cosmos.endpoint
 
       // BLOB STORAGE
-      MESSAGE_CONTENT_STORAGE_CONNECTION_STRING = var.message_content_storage.connection_string
-      MESSAGE_CONTENT_STORAGE_ENDPOINT          = var.message_content_storage.endpoint
-      MESSAGE_CONTAINER_NAME                    = "message-content"
+      MESSAGE_CONTENT_STORAGE_ENDPOINT = var.message_content_storage.endpoint
+      MESSAGE_CONTAINER_NAME           = "message-content"
 
       // REDIS
       REDIS_URL      = var.redis_cache.hostname


### PR DESCRIPTION
Needed for deploy again in order to definetely remove the conneciton string from the Terraform configuration of citizen-func