### PR TITLE
Messages-app get message ports and adapters

### DIFF
--- a/.changeset/shiny-candies-sing.md
+++ b/.changeset/shiny-candies-sing.md
@@ -1,0 +1,5 @@
+---
+"messages-app": patch
+---
+
+update required ports and adapters for the upcoming getMessage implementation

--- a/apps/messages-app/src/adapters/outbound/message/__tests__/message-content.adapter.test.ts
+++ b/apps/messages-app/src/adapters/outbound/message/__tests__/message-content.adapter.test.ts
@@ -164,3 +164,93 @@ describe("getMessagesContentByIds", () => {
     expect(trackEventMock).not.toHaveBeenCalled();
   });
 });
+
+describe("getMessageContentById", () => {
+  beforeEach(() => {
+    downloadToBufferMock.mockReset();
+    downloadToBufferMock.mockImplementation(() =>
+      Promise.resolve(aValidBuffer),
+    );
+    trackEventMock.mockReset();
+  });
+
+  it("returns the content for an existing valid message", async () => {
+    const result = await adapter.getMessageContentById("id-1");
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toEqual(aValidMessageContent);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a NotFoundError when the blob does not exist", async () => {
+    downloadToBufferMock.mockImplementation(() =>
+      Promise.reject(new RestError("not found", { statusCode: 404 })),
+    );
+
+    const result = await adapter.getMessageContentById("missing");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a MalformedEntityError when the content is invalid", async () => {
+    downloadToBufferMock.mockImplementation(() =>
+      Promise.resolve(Buffer.from(JSON.stringify({ subject: "" }))),
+    );
+
+    const result = await adapter.getMessageContentById("malformed");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(MalformedEntityError);
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a MalformedEntityError when the buffer is not valid JSON", async () => {
+    downloadToBufferMock.mockImplementation(() =>
+      Promise.resolve(Buffer.from("not-a-json")),
+    );
+
+    const result = await adapter.getMessageContentById("broken-json");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(MalformedEntityError);
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a TooManyRequestsError on throttling", async () => {
+    downloadToBufferMock.mockImplementation(() =>
+      Promise.reject(new RestError("throttled", { statusCode: 429 })),
+    );
+
+    const result = await adapter.getMessageContentById("id-1");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(TooManyRequestsError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a GenericError on an unexpected RestError status", async () => {
+    downloadToBufferMock.mockImplementation(() =>
+      Promise.reject(new RestError("boom", { statusCode: 500 })),
+    );
+
+    const result = await adapter.getMessageContentById("id-1");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a GenericError on non-RestError failures", async () => {
+    downloadToBufferMock.mockImplementation(() =>
+      Promise.reject(new Error("unexpected")),
+    );
+
+    const result = await adapter.getMessageContentById("id-1");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/messages-app/src/adapters/outbound/message/__tests__/message-metadata.adapter.test.ts
+++ b/apps/messages-app/src/adapters/outbound/message/__tests__/message-metadata.adapter.test.ts
@@ -2,12 +2,15 @@ import {
   CosmosClient,
   CosmosDiagnostics,
   FeedResponse,
+  Item,
+  ItemResponse,
   RestError,
   SqlQuerySpec,
 } from "@azure/cosmos";
 import {
   FiscalCodeSchema,
   GenericError,
+  NotFoundError,
   TooManyRequestsError,
 } from "@pagopa/hexagonal-core";
 import { Logger } from "@pagopa/hexagonal-core/domain/ports";
@@ -55,6 +58,12 @@ const queryMock = vi
   .spyOn(container.items, "query")
   .mockReturnValue(queryIterator);
 const fetchNextMock = vi.spyOn(queryIterator, "fetchNext");
+
+const item = container.item(aMessageMetadata.id, aFiscalCode);
+vi.spyOn(container, "item").mockReturnValue(item as Item);
+const readMock = vi.spyOn(item, "read").mockResolvedValue({
+  resource: aMessageMetadata,
+} as unknown as ItemResponse<never>);
 
 const trackEventMock = vi.fn();
 const adapter = new MessageMetadataCosmosAdapter(
@@ -179,6 +188,109 @@ describe("getMessagesMetadataByUser", () => {
     fetchNextMock.mockRejectedValue(new Error("unexpected"));
 
     const result = await adapter.getMessagesMetadataByUser(aFiscalCode, 10);
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getMessageMetadataByFiscalCodeAndId", () => {
+  beforeEach(() => {
+    readMock.mockReset();
+    readMock.mockResolvedValue({
+      resource: aMessageMetadata,
+    } as unknown as ItemResponse<never>);
+    trackEventMock.mockReset();
+  });
+
+  it("returns the metadata for an existing message", async () => {
+    const result = await adapter.getMessageMetadataByFiscalCodeAndId(
+      aFiscalCode,
+      aMessageMetadata.id,
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toEqual(aMessageMetadata);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a NotFoundError when the resource is undefined", async () => {
+    readMock.mockResolvedValue({
+      resource: undefined,
+    } as unknown as ItemResponse<never>);
+
+    const result = await adapter.getMessageMetadataByFiscalCodeAndId(
+      aFiscalCode,
+      "missing-id",
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a NotFoundError when Cosmos throws a 404 RestError", async () => {
+    readMock.mockRejectedValue(new RestError("not found", { statusCode: 404 }));
+
+    const result = await adapter.getMessageMetadataByFiscalCodeAndId(
+      aFiscalCode,
+      "missing-id",
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a GenericError when the resource does not match the schema", async () => {
+    readMock.mockResolvedValue({
+      resource: { ...aMessageMetadata, id: "not-a-ulid" },
+    } as unknown as ItemResponse<never>);
+
+    const result = await adapter.getMessageMetadataByFiscalCodeAndId(
+      aFiscalCode,
+      "malformed-id",
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a TooManyRequestsError when Cosmos throttles the request", async () => {
+    readMock.mockRejectedValue(new RestError("throttled", { statusCode: 429 }));
+
+    const result = await adapter.getMessageMetadataByFiscalCodeAndId(
+      aFiscalCode,
+      aMessageMetadata.id,
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(TooManyRequestsError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a GenericError on an unexpected Cosmos RestError", async () => {
+    readMock.mockRejectedValue(new RestError("boom", { statusCode: 500 }));
+
+    const result = await adapter.getMessageMetadataByFiscalCodeAndId(
+      aFiscalCode,
+      aMessageMetadata.id,
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a GenericError on a non-RestError failure", async () => {
+    readMock.mockRejectedValue(new Error("unexpected"));
+
+    const result = await adapter.getMessageMetadataByFiscalCodeAndId(
+      aFiscalCode,
+      aMessageMetadata.id,
+    );
 
     expect(result.isErr()).toBe(true);
     expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);

--- a/apps/messages-app/src/adapters/outbound/message/__tests__/message-metadata.adapter.test.ts
+++ b/apps/messages-app/src/adapters/outbound/message/__tests__/message-metadata.adapter.test.ts
@@ -16,6 +16,7 @@ import {
 import { Logger } from "@pagopa/hexagonal-core/domain/ports";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { MalformedEntityError } from "../../../../application/ports/error.js";
 import { MessageMetadata } from "../../../../application/ports/message-metadata.js";
 import { CryptoAdapter } from "../../crypto/crypto.adapter.js";
 import { MessageMetadataCosmosAdapter } from "../message-metadata.adapter.js";
@@ -243,7 +244,7 @@ describe("getMessageMetadataByFiscalCodeAndId", () => {
     expect(trackEventMock).not.toHaveBeenCalled();
   });
 
-  it("returns a GenericError when the resource does not match the schema", async () => {
+  it("returns a MalformedEntityError when the resource does not match the schema", async () => {
     readMock.mockResolvedValue({
       resource: { ...aMessageMetadata, id: "not-a-ulid" },
     } as unknown as ItemResponse<never>);
@@ -254,7 +255,7 @@ describe("getMessageMetadataByFiscalCodeAndId", () => {
     );
 
     expect(result.isErr()).toBe(true);
-    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(MalformedEntityError);
     expect(trackEventMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/messages-app/src/adapters/outbound/message/__tests__/message-status.adapter.test.ts
+++ b/apps/messages-app/src/adapters/outbound/message/__tests__/message-status.adapter.test.ts
@@ -5,10 +5,15 @@ import {
   RestError,
   SqlQuerySpec,
 } from "@azure/cosmos";
-import { GenericError, TooManyRequestsError } from "@pagopa/hexagonal-core";
+import {
+  GenericError,
+  NotFoundError,
+  TooManyRequestsError,
+} from "@pagopa/hexagonal-core";
 import { Logger } from "@pagopa/hexagonal-core/domain/ports";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { MalformedEntityError } from "../../../../application/ports/error.js";
 import { MessageStatus } from "../../../../application/ports/message-status.js";
 import { MessageStatusCosmosAdapter } from "../message-status.adapter.js";
 
@@ -141,6 +146,87 @@ describe("getLatestMessagesStatusByIds", () => {
     fetchNextMock.mockRejectedValue(new Error("unexpected"));
 
     const result = await adapter.getLatestMessagesStatusByIds(["id"]);
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("getLatestMessageStatusById", () => {
+  beforeEach(() => {
+    queryMock.mockClear();
+    fetchNextMock.mockReset();
+    fetchNextMock.mockResolvedValue(feedResponseWith([aMessageStatus]));
+    trackEventMock.mockReset();
+  });
+
+  it("returns the latest status for a given message", async () => {
+    const result = await adapter.getLatestMessageStatusById(
+      aMessageStatus.messageId,
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toEqual(aMessageStatus);
+
+    const expectedQuery: SqlQuerySpec = {
+      parameters: [{ name: "@messageId", value: aMessageStatus.messageId }],
+      query:
+        "SELECT * FROM c WHERE c.messageId = @messageId ORDER BY c.version DESC OFFSET 0 LIMIT 1",
+    };
+    expect(queryMock).toHaveBeenCalledWith(expectedQuery, {
+      partitionKey: aMessageStatus.messageId,
+    });
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a NotFoundError when no status exists for the message", async () => {
+    fetchNextMock.mockResolvedValue(feedResponseWith([]));
+
+    const result = await adapter.getLatestMessageStatusById("missing");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(NotFoundError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a MalformedEntityError when the status does not match the schema", async () => {
+    const aMalformedStatus = { ...aMessageStatus, messageId: "" };
+    fetchNextMock.mockResolvedValue(feedResponseWith([aMalformedStatus]));
+
+    const result = await adapter.getLatestMessageStatusById("malformed");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(MalformedEntityError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a TooManyRequestsError when Cosmos throttles the request", async () => {
+    fetchNextMock.mockRejectedValue(
+      new RestError("throttled", { statusCode: 429 }),
+    );
+
+    const result = await adapter.getLatestMessageStatusById("id");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(TooManyRequestsError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a GenericError on an unexpected Cosmos RestError", async () => {
+    fetchNextMock.mockRejectedValue(new RestError("boom", { statusCode: 500 }));
+
+    const result = await adapter.getLatestMessageStatusById("id");
+
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
+    expect(trackEventMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a GenericError on a non-RestError failure", async () => {
+    fetchNextMock.mockRejectedValue(new Error("unexpected"));
+
+    const result = await adapter.getLatestMessageStatusById("id");
+
     expect(result.isErr()).toBe(true);
     expect(result._unsafeUnwrapErr()).toBeInstanceOf(GenericError);
     expect(trackEventMock).not.toHaveBeenCalled();

--- a/apps/messages-app/src/adapters/outbound/message/message-content.adapter.ts
+++ b/apps/messages-app/src/adapters/outbound/message/message-content.adapter.ts
@@ -79,7 +79,9 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
 
   // parseContent perform runtime validation over the buffer.
   // errors short-circuit and fail the whole operation.
-  #parseContent(buffer: Buffer): Result<MessageContent, GenericError> {
+  #parseContent(
+    buffer: Buffer,
+  ): Result<MessageContent, GenericError | MalformedEntityError> {
     const parsedMessageContent = fromThrowable(
       () => blobMessageContentSchema.parse(JSON.parse(buffer.toString())),
       () =>
@@ -87,7 +89,7 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
     )();
 
     if (parsedMessageContent.isErr()) {
-      return err(parsedMessageContent.error);
+      return err(new MalformedEntityError(parsedMessageContent.error.message));
     }
 
     return ok(toMessageContent(parsedMessageContent.value));
@@ -144,11 +146,7 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
           messageID,
         },
       });
-      return err(
-        new MalformedEntityError(
-          `invalid message content for message with id: ${messageID}" ${parsedContent.error.name}: ${parsedContent.error.message}`,
-        ),
-      );
+      return err(parsedContent.error);
     }
 
     return ok(parsedContent.value);

--- a/apps/messages-app/src/adapters/outbound/message/message-content.adapter.ts
+++ b/apps/messages-app/src/adapters/outbound/message/message-content.adapter.ts
@@ -77,9 +77,25 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
       blobServiceClient.getContainerClient(containerName);
   }
 
-  // getContentById returns the content of the message identified by
+  // getMessageContentById returns the content of the message identified by
+  // errors short-circuit and fail the whole operation.
+  #parseContent(buffer: Buffer): Result<MessageContent, GenericError> {
+    const parsedMessageContent = fromThrowable(
+      () => blobMessageContentSchema.parse(JSON.parse(buffer.toString())),
+      () =>
+        new GenericError(`Invalid messageContentSchema for message content`),
+    )();
+
+    if (parsedMessageContent.isErr()) {
+      return err(parsedMessageContent.error);
+    }
+
+    return ok(toMessageContent(parsedMessageContent.value));
+  }
+
+  // parseContent perform runtime validation over the buffer.
   // `messageID`.
-  async #getContentById(
+  async getMessageContentById(
     messageID: string,
   ): Promise<
     Result<
@@ -123,7 +139,7 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
     if (parsedContent.isErr()) {
       // In this case we know that the message content is malformed
       this.logger.trackEvent({
-        name: "MessageContentBlobAdapter.getContentById.failed.parse",
+        name: "MessageContentBlobAdapter.getMessageContentById.failed.parse",
         properties: {
           messageID,
         },
@@ -138,22 +154,6 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
     return ok(parsedContent.value);
   }
 
-  // parseContent perform runtime validation over the buffer.
-  // errors short-circuit and fail the whole operation.
-  #parseContent(buffer: Buffer): Result<MessageContent, GenericError> {
-    const parsedMessageContent = fromThrowable(
-      () => blobMessageContentSchema.parse(JSON.parse(buffer.toString())),
-      () =>
-        new GenericError(`Invalid messageContentSchema for message content`),
-    )();
-
-    if (parsedMessageContent.isErr()) {
-      return err(parsedMessageContent.error);
-    }
-
-    return ok(toMessageContent(parsedMessageContent.value));
-  }
-
   async getMessagesContentByIds(
     messageIDs: string[],
   ): Promise<
@@ -163,7 +163,7 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
     >
   > {
     const results = await Promise.all(
-      messageIDs.map((messageID) => this.#getContentById(messageID)),
+      messageIDs.map((messageID) => this.getMessageContentById(messageID)),
     );
 
     const contentById = new Map<

--- a/apps/messages-app/src/adapters/outbound/message/message-content.adapter.ts
+++ b/apps/messages-app/src/adapters/outbound/message/message-content.adapter.ts
@@ -77,7 +77,7 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
       blobServiceClient.getContainerClient(containerName);
   }
 
-  // getMessageContentById returns the content of the message identified by
+  // parseContent perform runtime validation over the buffer.
   // errors short-circuit and fail the whole operation.
   #parseContent(buffer: Buffer): Result<MessageContent, GenericError> {
     const parsedMessageContent = fromThrowable(
@@ -93,7 +93,7 @@ export class MessageContentBlobAdapter implements MessageContentRepository {
     return ok(toMessageContent(parsedMessageContent.value));
   }
 
-  // parseContent perform runtime validation over the buffer.
+  // getMessageContentById returns the content of the message identified by
   // `messageID`.
   async getMessageContentById(
     messageID: string,

--- a/apps/messages-app/src/adapters/outbound/message/message-metadata.adapter.ts
+++ b/apps/messages-app/src/adapters/outbound/message/message-metadata.adapter.ts
@@ -9,6 +9,7 @@ import {
 import {
   FiscalCode,
   GenericError,
+  NotFoundError,
   TooManyRequestsError,
 } from "@pagopa/hexagonal-core";
 import { Result, ResultAsync, err, ok } from "neverthrow";
@@ -64,6 +65,72 @@ export class MessageMetadataCosmosAdapter implements MessageMetadataRepository {
     this.#cosmosContainer = cosmosClient
       .database(databaseName)
       .container(containerName);
+  }
+
+  async getMessageMetadataByFiscalCodeAndId(
+    fiscalCode: FiscalCode,
+    messageId: string,
+  ): Promise<
+    Result<MessageMetadata, GenericError | NotFoundError | TooManyRequestsError>
+  > {
+    // Messages are partitioned by `fiscalCode`, so this is an efficient
+    // single-partition point read.
+    const readResult = await ResultAsync.fromPromise(
+      this.#cosmosContainer
+        .item(messageId, fiscalCode)
+        .read<CosmosMessageMetadata>(),
+      (e) => {
+        if (e instanceof RestError) {
+          switch (e.statusCode) {
+            case 404:
+              return new NotFoundError(
+                "message metadata",
+                `cannot find message metadata for message ${messageId}`,
+              );
+            case 429:
+              return new TooManyRequestsError();
+            default:
+              return new GenericError(
+                `error obtaining message metadata for message ${messageId}: ${e.name}: ${e.message}`,
+              );
+          }
+        }
+        return new GenericError(
+          `error obtaining message metadata for message ${messageId}: ${e}`,
+        );
+      },
+    );
+
+    if (readResult.isErr()) {
+      return err(readResult.error);
+    }
+
+    const { resource } = readResult.value;
+
+    if (!resource) {
+      return err(
+        new NotFoundError(
+          "message metadata",
+          `cannot find message metadata for message ${messageId}`,
+        ),
+      );
+    }
+
+    const parsed = cosmosMessageMetadataSchema.safeParse(resource);
+    if (!parsed.success) {
+      this.logger.trackEvent({
+        name: "MessageMetadataCosmosAdapter.getMessageMetadataByFiscalCodeAndId.failed.parse",
+        properties: {
+          fiscalCode: this.crypto.toSha256(fiscalCode),
+          messageId,
+        },
+      });
+      return err(
+        new GenericError(`invalid message metadata for message ${messageId}`),
+      );
+    }
+
+    return ok(toMessageMetadata(parsed.data));
   }
 
   async getMessagesMetadataByUser(

--- a/apps/messages-app/src/adapters/outbound/message/message-metadata.adapter.ts
+++ b/apps/messages-app/src/adapters/outbound/message/message-metadata.adapter.ts
@@ -16,6 +16,7 @@ import { Result, ResultAsync, err, ok } from "neverthrow";
 import z from "zod";
 
 import { CryptoRepository } from "../../../application/ports/crypto.js";
+import { MalformedEntityError } from "../../../application/ports/error.js";
 import {
   MessageMetadata,
   MessageMetadataRepository,
@@ -71,7 +72,10 @@ export class MessageMetadataCosmosAdapter implements MessageMetadataRepository {
     fiscalCode: FiscalCode,
     messageId: string,
   ): Promise<
-    Result<MessageMetadata, GenericError | NotFoundError | TooManyRequestsError>
+    Result<
+      MessageMetadata,
+      GenericError | MalformedEntityError | NotFoundError | TooManyRequestsError
+    >
   > {
     // Messages are partitioned by `fiscalCode`, so this is an efficient
     // single-partition point read.
@@ -125,9 +129,7 @@ export class MessageMetadataCosmosAdapter implements MessageMetadataRepository {
           messageId,
         },
       });
-      return err(
-        new GenericError(`invalid message metadata for message ${messageId}`),
-      );
+      return err(new MalformedEntityError(parsed.error.message));
     }
 
     return ok(toMessageMetadata(parsed.data));

--- a/apps/messages-app/src/adapters/outbound/message/message-status.adapter.ts
+++ b/apps/messages-app/src/adapters/outbound/message/message-status.adapter.ts
@@ -59,7 +59,7 @@ export class MessageStatusCosmosAdapter implements MessageStatusRepository {
       .container(containerName);
   }
 
-  async #getLatestStatusById(
+  async getLatestMessageStatusById(
     messageID: string,
   ): Promise<
     Result<
@@ -110,7 +110,7 @@ export class MessageStatusCosmosAdapter implements MessageStatusRepository {
       return err(
         new NotFoundError(
           "message status",
-          `cannot find any message sttus for message identified by id ${messageID}`,
+          `cannot find any message status for message identified by id ${messageID}`,
         ),
       );
     }
@@ -129,13 +129,12 @@ export class MessageStatusCosmosAdapter implements MessageStatusRepository {
     return ok(toMessageStatus(decoded.data));
   }
 
-  // getLatestStatusById returns the latest message status of the message
   // identified by `messageID`.
   async getLatestMessagesStatusByIds(
     messageIDs: string[],
   ): Promise<Result<MessageStatus[], GenericError | TooManyRequestsError>> {
     const results = await Promise.all(
-      messageIDs.map((messageID) => this.#getLatestStatusById(messageID)),
+      messageIDs.map((messageID) => this.getLatestMessageStatusById(messageID)),
     );
 
     const statuses: MessageStatus[] = [];

--- a/apps/messages-app/src/application/ports/message-content.ts
+++ b/apps/messages-app/src/application/ports/message-content.ts
@@ -48,6 +48,22 @@ export type MessageContent = z.TypeOf<typeof messageContentSchema>;
 
 export interface MessageContentRepository {
   /**
+   * Returns the content of the single message identified by the provided
+   * `messageId`.
+   *
+   * Returns a `NotFoundError` when the blob does not exist, a
+   * `MalformedEntityError` when the blob content cannot be parsed.
+   */
+  getMessageContentById(
+    messageId: string,
+  ): Promise<
+    Result<
+      MessageContent,
+      GenericError | MalformedEntityError | NotFoundError | TooManyRequestsError
+    >
+  >;
+
+  /**
    * Returns the contents of the messages identified by the provided message
    * ids. The blobs are retrieved in parallel.
    *

--- a/apps/messages-app/src/application/ports/message-metadata.ts
+++ b/apps/messages-app/src/application/ports/message-metadata.ts
@@ -1,6 +1,7 @@
 import {
   FiscalCode,
   GenericError,
+  NotFoundError,
   TooManyRequestsError,
 } from "@pagopa/hexagonal-core";
 import { Result } from "neverthrow";
@@ -25,6 +26,19 @@ export const messageMetadataSchema = z.object({
 export type MessageMetadata = z.TypeOf<typeof messageMetadataSchema>;
 
 export interface MessageMetadataRepository {
+  /**
+   * Returns the metadata of the single message identified by the provided
+   * `messageId` belonging to the user identified by `fiscalCode`.
+   *
+   * Returns a `NotFoundError` when no such message exists.
+   */
+  getMessageMetadataByFiscalCodeAndId(
+    fiscalCode: FiscalCode,
+    messageId: string,
+  ): Promise<
+    Result<MessageMetadata, GenericError | NotFoundError | TooManyRequestsError>
+  >;
+
   /**
    * Returns a page of message metadata for the user identified by the provided
    * fiscal code. Content and status are retrieved separately.

--- a/apps/messages-app/src/application/ports/message-metadata.ts
+++ b/apps/messages-app/src/application/ports/message-metadata.ts
@@ -7,6 +7,8 @@ import {
 import { Result } from "neverthrow";
 import z from "zod";
 
+import { MalformedEntityError } from "./error.js";
+
 export const featureLevelSchema = z
   .enum(["ADVANCED", "STANDARD"])
   .default("STANDARD");
@@ -36,7 +38,10 @@ export interface MessageMetadataRepository {
     fiscalCode: FiscalCode,
     messageId: string,
   ): Promise<
-    Result<MessageMetadata, GenericError | NotFoundError | TooManyRequestsError>
+    Result<
+      MessageMetadata,
+      GenericError | MalformedEntityError | NotFoundError | TooManyRequestsError
+    >
   >;
 
   /**

--- a/apps/messages-app/src/application/ports/message-status.ts
+++ b/apps/messages-app/src/application/ports/message-status.ts
@@ -1,6 +1,12 @@
-import { GenericError, TooManyRequestsError } from "@pagopa/hexagonal-core";
+import {
+  GenericError,
+  NotFoundError,
+  TooManyRequestsError,
+} from "@pagopa/hexagonal-core";
 import { Result } from "neverthrow";
 import z from "zod";
+
+import { MalformedEntityError } from "./error.js";
 
 export const notRejectedMessageStatusValueSchema = z.enum([
   "ACCEPTED",
@@ -28,6 +34,22 @@ export const messageStatusSchema = z.object({
 export type MessageStatus = z.TypeOf<typeof messageStatusSchema>;
 
 export interface MessageStatusRepository {
+  /**
+   * Returns the latest version of the status for the single message identified
+   * by the provided `messageId`.
+   *
+   * Returns a `NotFoundError` when no status exists for the message, a
+   * `MalformedEntityError` when the stored document cannot be parsed.
+   */
+  getLatestMessageStatusById(
+    messageId: string,
+  ): Promise<
+    Result<
+      MessageStatus,
+      GenericError | MalformedEntityError | NotFoundError | TooManyRequestsError
+    >
+  >;
+
   /**
    * Returns the latest version of the status for each of the messages
    * identified by the provided message ids.


### PR DESCRIPTION
Updated ports and relative adapters required for the upcoming getMessage implementation:

add getMessageContentById
add getMessageMetadataByFiscalCodeAndId
add getLatestMessageStatusById

Closes IOCOM-3237